### PR TITLE
refactor(compiler): Refactoring the compiler module structure to opti…

### DIFF
--- a/libraries/zc/core/units.h
+++ b/libraries/zc/core/units.h
@@ -910,7 +910,7 @@ inline constexpr Bounded<zc::max(aN, bN), WiderType<A, B>> max(Bounded<aN, A> a,
 // We need to override min() and max() because:
 // 1) WiderType<> might not choose the correct bounds.
 // 2) One of the two sides of the ternary operator in the default implementation would fail to
-//    typecheck even though it is OK in practice.
+//    checker even though it is OK in practice.
 
 // -------------------------------------------------------------------
 // Operators between Bounded and BoundedConst

--- a/products/zomlang/compiler/CMakeLists.txt
+++ b/products/zomlang/compiler/CMakeLists.txt
@@ -4,27 +4,28 @@ add_subdirectory(driver)
 add_subdirectory(lexer)
 add_subdirectory(parser)
 add_subdirectory(source)
-add_subdirectory(typecheck)
-add_subdirectory(zis)
+add_subdirectory(checker)
+add_subdirectory(ast)
 
 add_library(
   frontend STATIC
+  $<TARGET_OBJECTS:ast>
   $<TARGET_OBJECTS:basic>
+  $<TARGET_OBJECTS:checker>
   $<TARGET_OBJECTS:diagnostics>
   $<TARGET_OBJECTS:driver>
   $<TARGET_OBJECTS:lexer>
   $<TARGET_OBJECTS:parser>
-  $<TARGET_OBJECTS:source>
-  $<TARGET_OBJECTS:typecheck>)
+  $<TARGET_OBJECTS:source>)
 target_link_libraries(frontend PUBLIC zc)
 
 set_target_include_directories(
   "${INCLUDE_DIRS}"
-  frontend
+  ast
   basic
+  checker
   diagnostics
   driver
   lexer
   parser
-  source
-  typecheck)
+  source)

--- a/products/zomlang/compiler/ast/CMakeLists.txt
+++ b/products/zomlang/compiler/ast/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(ast STATIC ast.cc)

--- a/products/zomlang/compiler/ast/ast.cc
+++ b/products/zomlang/compiler/ast/ast.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2024-2025 Zode.Z. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "zomlang/compiler/ast/ast.h"
+
+#include "zc/core/memory.h"
+#include "zc/core/string.h"
+
+namespace zomlang {
+namespace compiler {
+namespace ast {
+
+// ================================================================================
+// BinaryExpression::Impl
+
+struct BinaryExpression::Impl {
+  zc::Own<Expression> left;
+  zc::String op;
+  zc::Own<Expression> right;
+
+  Impl(zc::Own<Expression> l, zc::String o, zc::Own<Expression> r)
+      : left(zc::mv(l)), op(zc::mv(o)), right(zc::mv(r)) {}
+};
+
+// ================================================================================
+// BinaryExpression
+
+BinaryExpression::BinaryExpression(zc::Own<Expression> left, zc::String op,
+                                   zc::Own<Expression> right)
+    : impl(zc::heap<Impl>(zc::mv(left), zc::mv(op), zc::mv(right))) {}
+
+BinaryExpression::~BinaryExpression() noexcept = default;
+
+const Expression* BinaryExpression::getLeft() const { return impl->left.get(); }
+
+zc::StringPtr BinaryExpression::getOp() const { return impl->op; }
+
+const Expression* BinaryExpression::getRight() const { return impl->right.get(); }
+
+// ================================================================================
+// VariableDeclaration::Impl
+
+struct VariableDeclaration::Impl {
+  zc::String type;
+  zc::String name;
+  zc::Own<Expression> initializer;
+
+  Impl(zc::String t, zc::String n, zc::Own<Expression> init)
+      : type(zc::mv(t)), name(zc::mv(n)), initializer(zc::mv(init)) {}
+};
+
+// ================================================================================
+// VariableDeclaration
+
+VariableDeclaration::VariableDeclaration(zc::String type, zc::String name,
+                                         zc::Own<Expression> initializer)
+    : impl(zc::heap<Impl>(zc::mv(type), zc::mv(name), zc::mv(initializer))) {}
+
+VariableDeclaration::~VariableDeclaration() noexcept = default;
+
+zc::StringPtr VariableDeclaration::getType() const { return impl->type; }
+
+zc::StringPtr VariableDeclaration::getName() const { return impl->name; }
+
+const Expression* VariableDeclaration::getInitializer() const {
+  return impl->initializer.get();  // 返回裸指针
+}
+
+}  // namespace ast
+}  // namespace compiler
+}  // namespace zomlang

--- a/products/zomlang/compiler/ast/ast.h
+++ b/products/zomlang/compiler/ast/ast.h
@@ -14,53 +14,58 @@
 
 #pragma once
 
+#include "zc/core/memory.h"
 #include "zc/core/string.h"
 
 namespace zomlang {
 namespace compiler {
-namespace zis {
+namespace ast {
 
-class ZIS {
+class AST {
 public:
-  virtual ~ZIS() noexcept = default;
+  virtual ~AST() noexcept = default;
 };
 
-class Expression : public ZIS {
+class Expression : public AST {
 public:
   ~Expression() noexcept override = default;
 };
 
-class Statement : public ZIS {
+class Statement : public AST {
 public:
   ~Statement() noexcept override = default;
 };
 
 class BinaryExpression : public Expression {
 public:
-  ~BinaryExpression() noexcept override = default;
+  BinaryExpression(zc::Own<Expression> left, zc::String op, zc::Own<Expression> right);
+  ~BinaryExpression() noexcept override;
+
+  const Expression* getLeft() const;
+  zc::StringPtr getOp() const;
+  const Expression* getRight() const;
 
 private:
-  zc::Own<Expression> left;
-  zc::String op;
-  zc::Own<Expression> right;
+  struct Impl;
+  zc::Own<Impl> impl;
 };
 
 class VariableDeclaration : public Statement {
 public:
-  ~VariableDeclaration() noexcept override = default;
+  VariableDeclaration(zc::String type, zc::String name, zc::Own<Expression> initializer);
+  ~VariableDeclaration() noexcept override;
 
-  zc::StringPtr getType() const { return type; }
-
-  zc::StringPtr getName() const { return name; }
+  zc::StringPtr getType() const;
+  zc::StringPtr getName() const;
+  const Expression* getInitializer() const;
 
 private:
-  zc::String type;
-  zc::String name;
-  zc::Own<Expression> initializer;
+  struct Impl;
+  zc::Own<Impl> impl;
 };
 
-// Add more ZIS node types as needed
+// Add more AST node types as needed
 
-}  // namespace zis
+}  // namespace ast
 }  // namespace compiler
 }  // namespace zomlang

--- a/products/zomlang/compiler/basic/CMakeLists.txt
+++ b/products/zomlang/compiler/basic/CMakeLists.txt
@@ -1,3 +1,3 @@
-file(GLOB BASIC_SRC frontend.cc)
+set(BASIC_SRC ${CMAKE_CURRENT_SOURCE_DIR}/frontend.cc ${CMAKE_CURRENT_SOURCE_DIR}/thread-pool.cc)
 
 add_library(basic STATIC ${BASIC_SRC})

--- a/products/zomlang/compiler/basic/frontend.cc
+++ b/products/zomlang/compiler/basic/frontend.cc
@@ -14,11 +14,50 @@
 
 #include "zomlang/compiler/basic/frontend.h"
 
-#include "zc/core/map.h"
-#include "zomlang/compiler/zis/zis.h"
+#include "zc/core/vector.h"
+#include "zomlang/compiler/ast/ast.h"
+#include "zomlang/compiler/basic/zomlang-opts.h"
+#include "zomlang/compiler/diagnostics/diagnostic-engine.h"
+#include "zomlang/compiler/lexer/lexer.h"
+#include "zomlang/compiler/parser/parser.h"
+#include "zomlang/compiler/source/manager.h"
 
 namespace zomlang {
 namespace compiler {
-namespace basic {}  // namespace basic
+namespace basic {
+
+// Implementation of performParse
+zc::Maybe<zc::Own<ast::AST>> performParse(source::SourceManager& sm,
+                                          diagnostics::DiagnosticEngine& diags,
+                                          const LangOptions& langOpts, source::BufferId bufferId) {
+  // 1. Lexing
+  lexer::Lexer lexer(langOpts, sm, diags, bufferId);
+  zc::Vector<lexer::Token> tokens;
+  lexer::Token currentToken;
+  do {
+    lexer.lex(currentToken);
+    tokens.add(currentToken);
+  } while (currentToken.getKind() != lexer::TokenKind::kEOF);
+
+  // Check for lexing errors before parsing
+  if (diags.hasErrors()) {
+    return zc::none;  // Don't proceed if lexing failed
+  }
+
+  // 2. Parsing
+  parser::Parser parser(diags, bufferId);
+  // Assuming Parser::parse now returns the AST or null on failure
+  zc::Maybe<zc::Own<ast::AST>> ast = parser.parse(tokens.asPtr());
+
+  // Check for parsing errors
+  if (diags.hasErrors()) {
+    return zc::none;  // Return none if parsing reported errors
+  }
+
+  // Return the parsed AST (or none if parser returned none)
+  return zc::mv(ast);
+}
+
+}  // namespace basic
 }  // namespace compiler
 }  // namespace zomlang

--- a/products/zomlang/compiler/basic/frontend.h
+++ b/products/zomlang/compiler/basic/frontend.h
@@ -15,22 +15,31 @@
 #pragma once
 
 #include "zc/core/memory.h"
-#include "zc/core/mutex.h"
 
 namespace zomlang {
 namespace compiler {
 
 namespace source {
 class Module;
+class SourceManager;
+class BufferId;
+}  // namespace source
+
+namespace diagnostics {
+class DiagnosticEngine;
 }
 
-namespace zis {
-class ZIS;
+namespace ast {
+class AST;
 }
 
 namespace basic {
 
-zc::Maybe<zis::ZIS> performParse(source::Module& module);
+struct LangOptions;
+
+zc::Maybe<zc::Own<ast::AST>> performParse(source::SourceManager& sm,
+                                          diagnostics::DiagnosticEngine& diags,
+                                          const LangOptions& langOpts, source::BufferId bufferId);
 
 }  // namespace basic
 }  // namespace compiler

--- a/products/zomlang/compiler/basic/thread-pool.cc
+++ b/products/zomlang/compiler/basic/thread-pool.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2024-2025 Zode.Z. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "zomlang/compiler/basic/thread-pool.h"
+
+#include "zc/core/common.h"
+#include "zc/core/debug.h"
+#include "zc/core/exception.h"
+#include "zc/core/thread.h"
+
+namespace zomlang {
+namespace compiler {
+namespace basic {
+
+ThreadPool::ThreadPool(size_t numThreads) : workers(numThreads) {
+  ZC_ASSERT(numThreads > 0);
+  // Create and start worker threads
+  for (size_t i = 0; i < numThreads; ++i) {
+    workers.add(zc::heap<zc::Thread>([this] { this->workerLoop(); }));
+  }
+}
+
+ThreadPool::~ThreadPool() {
+  {
+    auto lockedTasks = tasks.lockExclusive();
+    stop = true;
+    // Note: There is no explicit notify_all here. zc::_::Mutex::unlock handles waking up threads.
+    // To ensure all waiting threads are awakened to check the stop flag,
+    // we could potentially trigger it manually before unlock (if zc::Mutex supports it),
+    // or rely on the default behavior of unlock. The implementation details of zc::Mutex determine
+    // the best approach. Assuming unlock wakes up waiters.
+  }  // Unlock mutex
+
+  // Wait for all worker threads to finish
+  // zc::Thread destructor automatically joins the thread
+  workers.clear();  // Explicitly destroy and join threads
+}
+
+void ThreadPool::enqueue(zc::Function<void()> task) {
+  {
+    auto lockedTasks = tasks.lockExclusive();
+    if (stop) {
+      ZC_FAIL_ASSERT("enqueue on stopped ThreadPool");
+      return;  // Or throw an exception
+    }
+
+    lockedTasks->add(arena.allocate<Task>(zc::mv(task)));
+    // After adding the task, the unlock operation will automatically handle the wake-up logic
+    // (depending on zc::Mutex implementation)
+  }  // Unlock mutex and potentially wake up a waiting thread
+}
+
+void ThreadPool::workerLoop() {
+  while (true) {
+    zc::Maybe<Task&> taskToRun;
+    {
+      auto lockedTasks = tasks.lockExclusive();
+
+      // Use a lambda that captures `this` (or `stop`) and accepts the locked task list
+      lockedTasks.wait(
+          [this](const auto& taskList) {
+            // Check stop flag or if the task list (already locked) is not empty
+            return stop || !taskList.empty();
+          },
+          zc::none);
+
+      // Use lockedTasks directly as it's already locked
+      if (stop && lockedTasks->empty()) { return; }  // Exit loop if stopping and no tasks left
+
+      // Use lockedTasks directly
+      if (!lockedTasks->empty()) {
+        Task& taskRef = lockedTasks->front();  // Get task from the front (FIFO)
+        // Assuming zc::List has remove(Task&) or similar.
+        // If remove requires iterator, adjust accordingly.
+        // Let's assume remove(Task&) exists for simplicity based on original code.
+        lockedTasks->remove(taskRef);  // Remove the task from the list
+        taskToRun = taskRef;           // Assign the task to be run
+      }
+    }  // Unlock mutex
+
+    // If a task was successfully retrieved, execute it
+    ZC_IF_SOME(task, taskToRun) {
+      zc::Maybe<zc::Exception> exception = zc::runCatchingExceptions([&]() { task.func(); });
+      ZC_IF_SOME(e, exception) {
+        // Handle exceptions thrown during task execution, e.g., log the error
+        ZC_LOG(ERROR, "Task executed with exception: ", e.getDescription());
+      }
+    }
+  }
+}
+
+}  // namespace basic
+}  // namespace compiler
+}  // namespace zomlang

--- a/products/zomlang/compiler/basic/thread-pool.h
+++ b/products/zomlang/compiler/basic/thread-pool.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2024-2025 Zode.Z. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#pragma once
+
+#include "zc/core/arena.h"
+#include "zc/core/function.h"
+#include "zc/core/list.h"
+#include "zc/core/memory.h"
+#include "zc/core/mutex.h"
+#include "zc/core/thread.h"
+
+ZC_BEGIN_HEADER
+
+namespace zomlang {
+namespace compiler {
+namespace basic {
+
+class ThreadPool {
+public:
+  explicit ThreadPool(size_t numThreads);
+  ~ThreadPool();
+
+  /// Disallow copy and move operations
+  ZC_DISALLOW_COPY_AND_MOVE(ThreadPool);
+
+  /// Enqueue a task to the thread pool
+  void enqueue(zc::Function<void()> task);
+
+private:
+  /// Memory pool for storing tasks
+  zc::Arena arena;
+
+  /// Task structure, containing the task function and ListLink
+  struct Task {
+    zc::Function<void()> func;
+    zc::ListLink<Task> link;
+
+    explicit Task(zc::Function<void()> f) : func(zc::mv(f)) {}
+  };
+
+  /// Function executed by worker threads
+  void workerLoop();
+
+  /// Worker threads
+  zc::Vector<zc::Own<zc::Thread>> workers;
+
+  /// Mutex guarding the task queue and stop flag
+  zc::MutexGuarded<zc::List<Task, &Task::link>> tasks;
+
+  /// Stop flag
+  bool stop = false;
+};
+
+}  // namespace basic
+}  // namespace compiler
+}  // namespace zomlang
+
+ZC_END_HEADER

--- a/products/zomlang/compiler/basic/zomlang-opts.h
+++ b/products/zomlang/compiler/basic/zomlang-opts.h
@@ -16,6 +16,7 @@
 
 namespace zomlang {
 namespace compiler {
+namespace basic {
 
 struct LangOptions {
   bool useUnicode;
@@ -26,5 +27,6 @@ struct LangOptions {
   LangOptions() : useUnicode(true), allowDollarIdentifiers(false), supportRegexLiterals(true) {}
 };
 
+}  // namespace basic
 }  // namespace compiler
 }  // namespace zomlang

--- a/products/zomlang/compiler/checker/CMakeLists.txt
+++ b/products/zomlang/compiler/checker/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(CHECKER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/checker.cc)
+
+add_library(checker STATIC "${CHECKER_SRC}")

--- a/products/zomlang/compiler/checker/checker.cc
+++ b/products/zomlang/compiler/checker/checker.cc
@@ -12,12 +12,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-#include "zomlang/compiler/typecheck/typechecker.h"
+#include "zomlang/compiler/checker/checker.h"
 
 #include "zc/core/common.h"
 #include "zc/core/string.h"
-#include "zomlang/compiler/zis/zis.h"
+#include "zomlang/compiler/ast/ast.h"
 
 namespace zomlang {
-namespace typecheck {}  // namespace typecheck
+namespace checker {}  // namespace checker
 }  // namespace zomlang

--- a/products/zomlang/compiler/checker/checker.h
+++ b/products/zomlang/compiler/checker/checker.h
@@ -14,16 +14,16 @@
 
 #pragma once
 
-#include "zomlang/compiler/typecheck/symbol-table.h"
-#include "zomlang/compiler/zis/zis.h"
+#include "zomlang/compiler/ast/ast.h"
+#include "zomlang/compiler/checker/symbol-table.h"
 
 namespace zomlang {
-namespace typecheck {
+namespace checker {
 
-// class TypeChecker : public CompilerStage<zc::Own<zis::ZIS>,
+// class TypeChecker : public CompilerStage<zc::Own<ast::AST>,
 // zc::String> {
 //  protected:
-//   void process(const zc::Own<zis::ZIS>& input,
+//   void process(const zc::Own<ast::AST>& input,
 //                zc::Vector<zc::String>& outputs) override;
 //
 //  private:
@@ -34,5 +34,5 @@ namespace typecheck {
 //   ~TypeChecker() noexcept override = default;
 // };
 
-}  // namespace typecheck
+}  // namespace checker
 }  // namespace zomlang

--- a/products/zomlang/compiler/checker/symbol-table.h
+++ b/products/zomlang/compiler/checker/symbol-table.h
@@ -19,7 +19,7 @@
 #include "zc/core/string.h"
 
 namespace zomlang {
-namespace typecheck {
+namespace checker {
 
 struct Symbol {
   zc::String name;
@@ -42,5 +42,5 @@ private:
   zc::HashMap<zc::String, zc::Own<Symbol>> symbols;
 };
 
-}  // namespace typecheck
+}  // namespace checker
 }  // namespace zomlang

--- a/products/zomlang/compiler/driver/driver.h
+++ b/products/zomlang/compiler/driver/driver.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "zc/core/string.h"
+#include "zomlang/compiler/basic/zomlang-opts.h"
 #include "zomlang/compiler/diagnostics/diagnostic-engine.h"
 
 namespace zomlang {
@@ -28,7 +29,7 @@ namespace driver {
 
 class CompilerDriver {
 public:
-  CompilerDriver() noexcept;
+  CompilerDriver(const basic::LangOptions& langOpts) noexcept;
   ~CompilerDriver() noexcept(false);
 
   /// Add a source file to the compiler.
@@ -39,6 +40,13 @@ public:
   /// Get the diagnostic engine used by the compiler.
   /// @return A reference to the diagnostic engine
   const diagnostics::DiagnosticEngine& getDiagnosticEngine() const;
+
+  /// Parses all added source files into ASTs.
+  /// @return True if parsing succeeded without fatal errors, false otherwise.
+  bool parseSources();
+
+  /// Potentially add a method to get the ASTs later
+  // zc::HashMap<source::BufferId, zc::Own<ast::TranslationUnit>>& getASTs();
 
 private:
   struct Impl;

--- a/products/zomlang/compiler/lexer/lexer.cc
+++ b/products/zomlang/compiler/lexer/lexer.cc
@@ -14,8 +14,7 @@
 
 #include "zomlang/compiler/lexer/lexer.h"
 
-#include <zomlang/compiler/basic/frontend.h>
-
+#include "zomlang/compiler/basic/frontend.h"
 #include "zomlang/compiler/diagnostics/in-flight-diagnostic.h"
 #include "zomlang/compiler/source/manager.h"
 
@@ -25,7 +24,7 @@ namespace lexer {
 
 struct Lexer::Impl {
   // Reference members
-  const LangOptions& langOpts;
+  const basic::LangOptions& langOpts;
   const source::SourceManager& sourceMgr;
   diagnostics::DiagnosticEngine& diags;
 
@@ -42,7 +41,7 @@ struct Lexer::Impl {
   LexerMode currentMode;
   CommentRetentionMode commentMode;
 
-  Impl(const LangOptions& options, const source::SourceManager& sm,
+  Impl(const basic::LangOptions& options, const source::SourceManager& sm,
        diagnostics::DiagnosticEngine& d, uint64_t bufferId)
       : langOpts(options),
         sourceMgr(sm),
@@ -109,7 +108,7 @@ struct Lexer::Impl {
   bool isOperatorStart(char c) const { /*...*/ return false; }
 };
 
-Lexer::Lexer(const LangOptions& options, const source::SourceManager& sourceMgr,
+Lexer::Lexer(const basic::LangOptions& options, const source::SourceManager& sourceMgr,
              diagnostics::DiagnosticEngine& diags, uint64_t bufferId)
     : impl(zc::heap<Impl>(options, sourceMgr, diags, bufferId)) {}
 Lexer::~Lexer() = default;

--- a/products/zomlang/compiler/lexer/lexer.h
+++ b/products/zomlang/compiler/lexer/lexer.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "zomlang/compiler/basic/zomlang-opts.h"
 #include "zomlang/compiler/diagnostics/diagnostic-engine.h"
 #include "zomlang/compiler/lexer/token.h"
 
@@ -32,7 +31,9 @@ class DiagnosticEngine;
 class InFlightDiagnostic;
 }  // namespace diagnostics
 
+namespace basic {
 struct LangOptions;
+}
 
 namespace lexer {
 
@@ -53,7 +54,7 @@ struct LexerState {
 
 class Lexer {
 public:
-  Lexer(const LangOptions& options, const source::SourceManager& sourceMgr,
+  Lexer(const basic::LangOptions& options, const source::SourceManager& sourceMgr,
         diagnostics::DiagnosticEngine& diags, uint64_t bufferId);
   ~Lexer();
 

--- a/products/zomlang/compiler/parser/CMakeLists.txt
+++ b/products/zomlang/compiler/parser/CMakeLists.txt
@@ -1,3 +1,3 @@
-file(GLOB PARSER_SRC "*.cc")
+set(PARSER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/parser.cc)
 
 add_library(parser STATIC ${PARSER_SRC})

--- a/products/zomlang/compiler/parser/parser.cc
+++ b/products/zomlang/compiler/parser/parser.cc
@@ -14,25 +14,36 @@
 
 #include "zomlang/compiler/parser/parser.h"
 
+#include "zomlang/compiler/ast/ast.h"
+
 namespace zomlang {
 namespace compiler {
 namespace parser {
 
 // ================================================================================
 // Parser::Impl
-class Parser::Impl {
-public:
-  Impl(diagnostics::DiagnosticEngine& diagnosticEngine, uint64_t bufferId) noexcept;
+struct Parser::Impl {
+  Impl(diagnostics::DiagnosticEngine& diagnosticEngine, uint64_t bufferId) noexcept
+      : bufferId(bufferId), diagnosticEngine(diagnosticEngine) {}
   ~Impl() noexcept(false) = default;
 
   ZC_DISALLOW_COPY_AND_MOVE(Impl);
 
-  void parse(zc::ArrayPtr<const lexer::Token> tokens);
-
-private:
   uint64_t bufferId;
   diagnostics::DiagnosticEngine& diagnosticEngine;
 };
+
+// ================================================================================
+// Parser
+
+Parser::Parser(diagnostics::DiagnosticEngine& diagnosticEngine, uint64_t bufferId) noexcept
+    : impl(zc::heap<Impl>(diagnosticEngine, bufferId)) {}
+
+Parser::~Parser() noexcept(false) = default;
+
+zc::Maybe<zc::Own<ast::AST>> Parser::parse(zc::ArrayPtr<const lexer::Token> tokens) {
+  return zc::none;
+}
 
 }  // namespace parser
 }  // namespace compiler

--- a/products/zomlang/compiler/parser/parser.h
+++ b/products/zomlang/compiler/parser/parser.h
@@ -19,19 +19,24 @@
 
 namespace zomlang {
 namespace compiler {
+
+namespace ast {
+class AST;
+}
+
 namespace parser {
 
 class Parser {
 public:
   Parser(diagnostics::DiagnosticEngine& diagnosticEngine, uint64_t bufferId) noexcept;
-  ~Parser() noexcept(false) = default;
+  ~Parser() noexcept(false);
 
   ZC_DISALLOW_COPY_AND_MOVE(Parser);
 
-  void parse(zc::ArrayPtr<const lexer::Token> tokens);
+  zc::Maybe<zc::Own<ast::AST>> parse(zc::ArrayPtr<const lexer::Token> tokens);
 
 private:
-  class Impl;
+  struct Impl;
   zc::Own<Impl> impl;
 };
 

--- a/products/zomlang/compiler/source/CMakeLists.txt
+++ b/products/zomlang/compiler/source/CMakeLists.txt
@@ -1,3 +1,5 @@
-file(GLOB SOURCE_SRC location.cc manager.cc)
+set(SOURCE_SRC
+  ${CMAKE_CURRENT_SOURCE_DIR}/location.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/manager.cc)
 
 add_library(source STATIC ${SOURCE_SRC})

--- a/products/zomlang/compiler/source/manager.cc
+++ b/products/zomlang/compiler/source/manager.cc
@@ -391,6 +391,13 @@ SourceLoc SourceManager::getLocFromExternalSource(const zc::StringPtr path, cons
   return {};
 }
 
+const zc::Vector<BufferId> SourceManager::getManagedBufferIds() const {
+  zc::Vector<BufferId> ids;
+  ids.reserve(impl->buffers.size());
+  for (const auto& buffer : impl->buffers) { ids.add(buffer->id); }
+  return ids;
+}
+
 }  // namespace source
 }  // namespace compiler
 }  // namespace zomlang

--- a/products/zomlang/compiler/source/manager.h
+++ b/products/zomlang/compiler/source/manager.h
@@ -17,6 +17,7 @@
 #include "zc/core/common.h"
 #include "zc/core/memory.h"
 #include "zc/core/string.h"
+#include "zc/core/vector.h"
 #include "zomlang/compiler/source/location.h"
 
 namespace zomlang {
@@ -137,6 +138,8 @@ public:
   /// Regex literal support
   void recordRegexLiteralStartLoc(const SourceLoc& loc);
   bool isRegexLiteralStart(const SourceLoc& loc) const;
+
+  const zc::Vector<BufferId> getManagedBufferIds() const;
 
 private:
   struct Impl;

--- a/products/zomlang/compiler/typecheck/CMakeLists.txt
+++ b/products/zomlang/compiler/typecheck/CMakeLists.txt
@@ -1,3 +1,0 @@
-file(GLOB TYPECHECK_SRC "*.cc")
-
-add_library(typecheck STATIC "${TYPECHECK_SRC}")

--- a/products/zomlang/compiler/zis/CMakeLists.txt
+++ b/products/zomlang/compiler/zis/CMakeLists.txt
@@ -1,1 +1,0 @@
-#add_library(zis STATIC typechecker.cc)

--- a/products/zomlang/unittests/compiler/basic/thread-pool-test.cc
+++ b/products/zomlang/unittests/compiler/basic/thread-pool-test.cc
@@ -1,0 +1,148 @@
+// Copyright (c) 2024-2025 Zode.Z. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "zomlang/compiler/basic/thread-pool.h"
+
+#include <stdlib.h>  // For rand
+#include <unistd.h>  // For usleep
+
+#include <atomic>
+
+#include "zc/core/common.h"
+#include "zc/core/debug.h"  // For ZC_FAIL_ASSERT
+#include "zc/core/exception.h"
+#include "zc/core/mutex.h"  // For MutexGuarded
+#include "zc/core/time.h"   // For MILLISECONDS, MICROSECONDS
+#include "zc/ztest/test.h"
+
+namespace zomlang {
+namespace compiler {
+namespace basic {
+
+ZC_TEST("ThreadPool: Basic Task Execution") {
+  std::atomic<int> counter = 0;  // Use atomic for thread safety if pool had > 1 thread initially
+  {                              // Scope the pool to ensure destruction before checking counter
+    ThreadPool pool(1);          // Use a single thread for predictable execution
+    pool.enqueue([&]() { counter++; });
+    // Pool destructor runs here, waits for the task.
+  }
+  // Now check the counter after the pool is destroyed and task should be complete.
+  ZC_EXPECT(counter == 1, counter);  // Add assertion here
+}
+
+ZC_TEST("ThreadPool: Multiple Tasks and Threads") {
+  const size_t numThreads = 4;
+  const int numTasks = 100;
+
+  // Block 1: pool and counter - Add scope to ensure pool destruction before counter goes out of
+  // scope
+  std::atomic<int> counter = 0;   // Declare counter outside the pool's immediate scope
+  {                               // Add a new scope for the first ThreadPool instance
+    ThreadPool pool(numThreads);  // pool is now inside this scope
+
+    for (int i = 0; i < numTasks; ++i) {
+      pool.enqueue([&]() {  // Lambda captures 'counter' by reference, which is safe now
+        // Simulate some work
+        usleep((zc::MILLISECONDS * (rand() % 5)) / zc::MICROSECONDS);
+        counter++;  // Accessing 'counter' (line 54 in original)
+      });
+    }
+    // 'pool' goes out of scope here, its destructor runs and waits for tasks.
+  }  // End of pool's scope
+
+  // At this point, all threads from 'pool' have finished accessing 'counter'.
+  ZC_EXPECT(counter == numTasks, counter);
+
+  // Block 2: poolCheck and counterCheck (This block was already correctly scoped)
+  std::atomic<int> counterCheck = 0;
+  {
+    ThreadPool poolCheck(numThreads);
+    zc::MutexGuarded<int> finishedTasksGuard(0);  // Use MutexGuarded
+
+    for (int i = 0; i < numTasks; ++i) {
+      poolCheck.enqueue([&]() {
+        usleep((zc::MILLISECONDS * (rand() % 2)) / zc::MICROSECONDS);
+        counterCheck++;
+        // Increment finished count under lock
+        (*finishedTasksGuard.lockExclusive())++;
+        // No explicit notify needed, MutexGuarded handles waking waiters
+      });
+    }
+
+    // Wait for all tasks to complete using MutexGuarded::when
+    finishedTasksGuard.when([](int count) { return count == numTasks; },
+                            [](int&) { /* No operation needed when condition met */ },
+                            zc::none);  // Wait indefinitely
+
+    // Pool destructor will still run and join, but tasks are already finished.
+  }
+
+  ZC_EXPECT(counterCheck == numTasks, counterCheck, numTasks);
+}
+
+ZC_TEST("ThreadPool: Destruction Waits for Tasks") {
+  std::atomic<bool> taskStarted = false;
+  std::atomic<bool> taskCompleted = false;
+  {
+    ThreadPool pool(1);
+    pool.enqueue([&]() {
+      taskStarted = true;
+      usleep((zc::MILLISECONDS * 50) / zc::MICROSECONDS);  // Simulate long task
+      taskCompleted = true;
+    });
+    // Pool destructor runs here
+  }
+  ZC_EXPECT(taskStarted == true);
+  ZC_EXPECT(taskCompleted == true);  // Destructor should block until task is done
+}
+
+// Note: Testing enqueue after stop currently triggers ZC_FAIL_ASSERT.
+// ZC_EXPECT_THROW cannot catch fatal assertions directly in the same process.
+// A death test (like expectFatalThrow in zc/ztest/test-helpers.h) would be needed,
+// but that requires fork(), which might not be universally available or desired.
+// We'll skip testing this specific assertion failure for now.
+/*
+ZC_TEST("ThreadPool: Enqueue After Stop (Requires Death Test)") {
+    ThreadPool pool(1);
+    pool.stop(); // Assuming a stop method exists or simulating via destructor start
+    // This requires a way to trigger the stop logic without full destruction if needed,
+    // or using a death test framework.
+    // ZC_EXPECT_THROW_MESSAGE("enqueue on stopped ThreadPool", pool.enqueue([]{}));
+}
+*/
+
+ZC_TEST("ThreadPool: Task Exception Handling") {
+  // Use LogExpectation to check if the error is logged
+  // This requires including "zc/ztest/test-helpers.h" potentially
+  // For simplicity, we'll just run it and rely on manual log inspection or
+  // a more advanced logging setup if available.
+
+  {
+    ThreadPool pool(1);
+    pool.enqueue([&]() {
+      ZC_EXPECT_LOG(ERROR, "Simulating task failure");
+      ZC_LOG(ERROR, "Simulating task failure");
+    });
+
+    // Allow time for the task to execute and potentially log the error
+    usleep((zc::MILLISECONDS * 100) / zc::MICROSECONDS);
+    // Pool destructor runs here
+  }
+
+  // Verification depends on the logging mechanism. ZC_LOG(ERROR, ...) is used in workerLoop.
+}
+
+}  // namespace basic
+}  // namespace compiler
+}  // namespace zomlang

--- a/products/zomlang/unittests/compiler/source/manager-test.cc
+++ b/products/zomlang/unittests/compiler/source/manager-test.cc
@@ -15,40 +15,40 @@
 #include "zomlang/compiler/source/manager.h"
 
 #include "zc/core/common.h"
-#include "zc/core/filesystem.h"
 #include "zc/core/string.h"
 #include "zc/ztest/test.h"
 #include "zomlang/compiler/source/location.h"
 
 namespace zomlang {
 namespace compiler {
+namespace source {
 
 ZC_TEST("SourceManager: Basic Memory Buffer Operations") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   // Empty Buffer Test
-  source::BufferId emptyId = manager.addMemBufferCopy({}, "empty.zom");
+  BufferId emptyId = manager.addMemBufferCopy({}, "empty.zom");
   ZC_EXPECT(manager.getEntireTextForBuffer(emptyId).size() == 0);
 
   // Common Text Test
   zc::StringPtr content = "Hello\nWorld\n"_zc;
-  source::BufferId bufferId = manager.addMemBufferCopy(content.asBytes(), "test.txt");
+  BufferId bufferId = manager.addMemBufferCopy(content.asBytes(), "test.txt");
   zc::ArrayPtr<const zc::byte> text = manager.getEntireTextForBuffer(bufferId);
   ZC_EXPECT(text.size() == 12);
   ZC_EXPECT(text == content.asBytes());
 }
 
 ZC_TEST("SourceManager: File System Operations") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   // Test non-existent file
-  zc::Maybe<source::BufferId> nonexistentResult = manager.getFileSystemSourceBufferID("non.txt");
+  zc::Maybe<BufferId> nonexistentResult = manager.getFileSystemSourceBufferID("non.txt");
   ZC_EXPECT(nonexistentResult == zc::none);
 
   // Test duplicate loading
   zc::StringPtr content = "test content"_zc;
-  source::BufferId id1 = manager.addMemBufferCopy(content.asBytes(), "same.txt");
-  source::BufferId id2 = manager.addMemBufferCopy(content.asBytes(), "same.txt");
+  BufferId id1 = manager.addMemBufferCopy(content.asBytes(), "same.txt");
+  BufferId id2 = manager.addMemBufferCopy(content.asBytes(), "same.txt");
   // Same path but potentially different content should get different IDs (though content is same
   // here) Or perhaps the intent was: Same path should ideally return the same ID if content is
   // identical and caching is implemented? Keeping the original logic: Expect different IDs as
@@ -57,54 +57,54 @@ ZC_TEST("SourceManager: File System Operations") {
 }
 
 ZC_TEST("SourceManager: Buffer Identification") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   // Test BufferId uniqueness
-  source::BufferId id1 = manager.addMemBufferCopy("content1"_zcb, "file1.txt");
-  source::BufferId id2 = manager.addMemBufferCopy("content2"_zcb, "file2.txt");
+  BufferId id1 = manager.addMemBufferCopy("content1"_zcb, "file1.txt");
+  BufferId id2 = manager.addMemBufferCopy("content2"_zcb, "file2.txt");
 
   ZC_EXPECT(id1 != id2);
   ZC_EXPECT(manager.getIdentifierForBuffer(id1) != manager.getIdentifierForBuffer(id2));
 }
 
 ZC_TEST("SourceManager: Source Location Navigation") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content =
       "Line1\n"
       "Line2\n"
       "Line3\n"_zc;
 
-  source::BufferId bufferId = manager.addMemBufferCopy(content.asBytes(), "nav.txt");
+  BufferId bufferId = manager.addMemBufferCopy(content.asBytes(), "nav.txt");
 
-  source::SourceLoc loc = manager.getLocForBufferStart(bufferId);
-  source::LineAndColumn lineCol = manager.getPresumedLineAndColumnForLoc(loc, bufferId);
+  SourceLoc loc = manager.getLocForBufferStart(bufferId);
+  LineAndColumn lineCol = manager.getPresumedLineAndColumnForLoc(loc, bufferId);
   ZC_EXPECT(lineCol.line == 1);
   ZC_EXPECT(lineCol.column == 1);
 
-  source::SourceLoc loc2 = manager.getLocForOffset(bufferId, 6);
-  source::LineAndColumn lineCol2 = manager.getPresumedLineAndColumnForLoc(loc2, bufferId);
+  SourceLoc loc2 = manager.getLocForOffset(bufferId, 6);
+  LineAndColumn lineCol2 = manager.getPresumedLineAndColumnForLoc(loc2, bufferId);
   ZC_EXPECT(lineCol2.line == 2);
   ZC_EXPECT(lineCol2.column == 1);
 
-  source::SourceLoc loc3 = manager.getLocForOffset(bufferId, 14);
-  source::LineAndColumn lineCol3 = manager.getPresumedLineAndColumnForLoc(loc3, bufferId);
+  SourceLoc loc3 = manager.getLocForOffset(bufferId, 14);
+  LineAndColumn lineCol3 = manager.getPresumedLineAndColumnForLoc(loc3, bufferId);
   ZC_EXPECT(lineCol3.line == 3);
   ZC_EXPECT(lineCol3.column == 3);
 }
 
 ZC_TEST("SourceManager: Source Ranges") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content = "Hello World"_zc;
-  source::BufferId bufferId = manager.addMemBufferCopy(content.asBytes(), "range.txt");
+  BufferId bufferId = manager.addMemBufferCopy(content.asBytes(), "range.txt");
 
-  source::CharSourceRange range = manager.getRangeForBuffer(bufferId);
+  CharSourceRange range = manager.getRangeForBuffer(bufferId);
   ZC_EXPECT(range.length() == 11);
 }
 
 ZC_TEST("SourceManager: Virtual File Layering") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content = "base content\nfor testing\n"_zc;
   auto bufferId = manager.addMemBufferCopy(content.asBytes(), "base.txt");
@@ -119,7 +119,7 @@ ZC_TEST("SourceManager: Virtual File Layering") {
 }
 
 ZC_TEST("SourceManager: Virtual File Interactions") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content = "content\nfor\nvirtual\nfile\n"_zc;
   auto bufferId = manager.addMemBufferCopy(content.asBytes(), "base.txt");
@@ -135,7 +135,7 @@ ZC_TEST("SourceManager: Virtual File Interactions") {
 }
 
 ZC_TEST("SourceManager: Line Column Operations") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content = "L1\nLine2\n\nIndented\n"_zc;
   auto bufferId = manager.addMemBufferCopy(content.asBytes(), "lines.txt");
@@ -156,7 +156,7 @@ ZC_TEST("SourceManager: Line Column Operations") {
 }
 
 ZC_TEST("SourceManager: Content Retrieval") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content = "First Line\nSecond Line\n"_zc;
   auto bufferId = manager.addMemBufferCopy(content.asBytes(), "content.txt");
@@ -167,21 +167,21 @@ ZC_TEST("SourceManager: Content Retrieval") {
 }
 
 ZC_TEST("SourceManager: Edge Cases and Error Handling") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   // Test invalid BufferId
-  source::BufferId invalidId(999999);
+  BufferId invalidId(999999);
   ZC_EXPECT_THROW_MESSAGE("expected impl->idToBuffer.find(bufferId) != nullptr",
                           manager.getEntireTextForBuffer(invalidId));
 
   // Test invalid location
-  source::SourceLoc invalidLoc;
+  SourceLoc invalidLoc;
   ZC_EXPECT_THROW_MESSAGE("Invalid source location",
                           manager.getPresumedLineAndColumnForLoc(invalidLoc, invalidId));
 }
 
 ZC_TEST("SourceManager: Performance") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   // Create a large file for performance testing
   zc::Array<zc::byte> largeContent = zc::heapArray<zc::byte>(1024 * 1024, 'x');
@@ -195,7 +195,7 @@ ZC_TEST("SourceManager: Performance") {
 }
 
 ZC_TEST("SourceManager: Special Characters") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   // Includes more special characters: Unicode, Tab, Newline, Space, Null character, CRLF
   zc::StringPtr content =
@@ -237,7 +237,7 @@ ZC_TEST("SourceManager: Special Characters") {
 }
 
 ZC_TEST("SourceManager: Content Comparison") {
-  source::SourceManager manager;
+  SourceManager manager;
 
   zc::StringPtr content1 = "Hello World"_zc;
   zc::StringPtr content2 = "Hello World"_zc;
@@ -253,5 +253,6 @@ ZC_TEST("SourceManager: Content Comparison") {
   ZC_EXPECT(text1.size() == content1.size());
 }
 
+}  // namespace source
 }  // namespace compiler
 }  // namespace zomlang


### PR DESCRIPTION
…mize CMake configuration and code organization

Refactor the CMake configuration of the compiler module to remove the old module and add the ast and checker modules. Improved code organization, moved LangOptions to the basic namespace, and improved Parser and Lexer implementations. The ThreadPool class was added to support parallel task processing, and the Driver and Frontend implementations were updated to support the new AST parsing flow.