### PR TITLE
fix(ci): fix codecov action parameter from 'file' to 'files'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Zzzode/ZOM
-          file: ${{github.workspace}}/build-coverage/coverage/coverage.lcov
+          files: ${{github.workspace}}/build-coverage/coverage/coverage.lcov
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true


### PR DESCRIPTION
The codecov-action@v5 expects 'files' parameter instead of 'file'. This fixes the CI warning about unexpected input parameter.