### PR TITLE
refactor: replace custom concepts with C++20 std::derived_from

### DIFF
--- a/products/zomlang/compiler/ast/ast.h
+++ b/products/zomlang/compiler/ast/ast.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <type_traits>
+#include <concepts>
 
 #include "zc/core/common.h"
 #include "zc/core/memory.h"
@@ -241,31 +241,8 @@ private:
 };
 
 // NodeList template class, used to store a list of nodes
-namespace _ {
-// Default case
-template <typename T, typename = void>
-struct IsNodeLike : std::false_type {};
-
-// Directly derived from Node
 template <typename T>
-struct IsNodeLike<T, std::enable_if_t<std::is_base_of_v<Node, T>>> : std::true_type {};
-
-// zc::Own<T>
-template <typename T>
-struct IsNodeLike<zc::Own<T>, std::enable_if_t<std::is_base_of_v<Node, T>>> : std::true_type {};
-
-// zc::Maybe<U> (Recursive)
-template <typename U>
-struct IsNodeLike<zc::Maybe<U>, std::enable_if_t<IsNodeLike<U>::value>> : std::true_type {};
-}  // namespace _
-
-template <typename T>
-concept FlexibleNodeType = _::IsNodeLike<T>::value;
-
-template <typename T>
-concept DerivedFromNode = std::is_base_of_v<Node, T>;
-
-template <DerivedFromNode T>
+  requires std::derived_from<T, Node>
 class NodeList {
 public:
   NodeList() noexcept {};
@@ -334,7 +311,8 @@ private:
 };
 
 // NodeList implementations of Iterator and ConstIterator
-template <DerivedFromNode T>
+template <typename T>
+  requires std::derived_from<T, Node>
 class NodeList<T>::Iterator {
 public:
   Iterator(zc::Vector<zc::Own<T>>& vec, size_t index) : vec(&vec), index(index) {}
@@ -358,7 +336,8 @@ private:
   size_t index;
 };
 
-template <DerivedFromNode T>
+template <typename T>
+  requires std::derived_from<T, Node>
 class NodeList<T>::ConstIterator {
 public:
   ConstIterator(const zc::Vector<zc::Own<T>>& vec, size_t index) : vec(&vec), index(index) {}

--- a/products/zomlang/compiler/ast/factory.h
+++ b/products/zomlang/compiler/ast/factory.h
@@ -118,13 +118,13 @@ zc::Own<SourceFile> createSourceFile(zc::String&& fileName,
                                      zc::Vector<zc::Own<ast::Statement>>&& statements);
 
 template <typename Node>
-  requires DerivedFromNode<Node>
+  requires std::derived_from<Node, ast::Node>
 const ast::NodeList<Node> createNodeList(zc::Vector<zc::Own<Node>>&& list) {
   return ast::NodeList<Node>(zc::mv(list));
 }
 
 template <typename Node, typename... Args>
-  requires DerivedFromNode<Node>
+  requires std::derived_from<Node, ast::Node>
 zc::Own<Node> createNodeWithRange(const source::SourceRange& range, Args&&... args) {
   zc::Own<Node> node = zc::heap<Node>(zc::fwd<Args>(args)...);
   node->setSourceRange(range);

--- a/products/zomlang/compiler/parser/parser.h
+++ b/products/zomlang/compiler/parser/parser.h
@@ -139,21 +139,21 @@ public:
 
 private:
   template <typename Node>
-    requires ast::DerivedFromNode<Node>
+    requires std::derived_from<Node, ast::Node>
   zc::Own<Node> finishNode(zc::Own<Node>&& node, source::SourceLoc pos) {
     const source::SourceLoc end = getFullStartLoc();
     return finishNode(zc::mv(node), zc::mv(pos), zc::mv(end));
   }
 
   template <typename Node>
-    requires ast::DerivedFromNode<Node>
+    requires std::derived_from<Node, ast::Node>
   zc::Own<Node> finishNode(zc::Own<Node>&& node, source::SourceLoc pos, source::SourceLoc end) {
     node->setSourceRange(source::SourceRange(pos, end));
     return zc::mv(node);
   }
 
   template <typename Node>
-    requires ast::DerivedFromNode<Node>
+    requires std::derived_from<Node, ast::Node>
   zc::Vector<zc::Own<Node>> parseList(ParsingContext context,
                                       zc::Function<zc::Maybe<zc::Own<Node>>()> parseElement) {
     zc::Vector<zc::Own<Node>> result;


### PR DESCRIPTION
- Replace custom `DerivedFromNode` concept with `std::derived_from<Node, ast::Node>`
- Replace custom `FlexibleNodeType` concept with direct `std::derived_from` constraints
- Remove unnecessary type traits in anonymous namespace `_`
- Update NodeList, Iterator, and ConstIterator templates to use C++20 concepts
- Modernize factory.h and parser.h to use standard library concepts

This change leverages C++20's built-in concepts for better readability and maintainability while maintaining the same type safety guarantees.

🤖 Generated with [Claude Code](https://claude.ai/code)