### PR TITLE
feat: add recursion depth limit to trace system

### DIFF
--- a/products/zomlang/compiler/ast/serializer.cc
+++ b/products/zomlang/compiler/ast/serializer.cc
@@ -17,78 +17,14 @@
 #include <cstdio>
 
 #include "zc/core/debug.h"
+#include "zc/core/string.h"
+#include "zc/core/vector.h"
+#include "zomlang/compiler/ast/ast.h"
+#include "zomlang/compiler/basic/string-escape.h"
 
 namespace zomlang {
 namespace compiler {
 namespace ast {
-
-// JSON string escaping helper function
-zc::String escapeJsonString(zc::StringPtr str) {
-  zc::Vector<char> result;
-  for (char c : str) {
-    switch (c) {
-      case '"':
-        result.addAll("\\\""_zc.asArray());
-        break;
-      case '\\':
-        result.addAll("\\\\"_zc.asArray());
-        break;
-      case '\b':
-        result.addAll("\\b"_zc.asArray());
-        break;
-      case '\f':
-        result.addAll("\\f"_zc.asArray());
-        break;
-      case '\n':
-        result.addAll("\\n"_zc.asArray());
-        break;
-      case '\r':
-        result.addAll("\\r"_zc.asArray());
-        break;
-      case '\t':
-        result.addAll("\\t"_zc.asArray());
-        break;
-      default:
-        if (static_cast<unsigned char>(c) < 0x20) {
-          char buffer[7];
-          std::snprintf(buffer, sizeof(buffer), "\\u%04x", static_cast<unsigned char>(c));
-          result.addAll(zc::ArrayPtr<const char>(buffer, 6));
-        } else {
-          result.add(c);
-        }
-        break;
-    }
-  }
-  return zc::str(result.asPtr());
-}
-
-// XML string escaping helper function
-zc::String escapeXmlString(zc::StringPtr str) {
-  zc::Vector<char> result;
-  for (char c : str) {
-    switch (c) {
-      case '<':
-        result.addAll("&lt;"_zc.asArray());
-        break;
-      case '>':
-        result.addAll("&gt;"_zc.asArray());
-        break;
-      case '&':
-        result.addAll("&amp;"_zc.asArray());
-        break;
-      case '"':
-        result.addAll("&quot;"_zc.asArray());
-        break;
-      case '\'':
-        result.addAll("&apos;"_zc.asArray());
-        break;
-      default:
-        result.add(c);
-        break;
-    }
-  }
-  return zc::str(result.asPtr());
-}
 
 // JSONSerializer implementation
 struct JSONSerializer::Impl {
@@ -148,7 +84,7 @@ void JSONSerializer::writeProperty(const zc::StringPtr name, const zc::StringPtr
   if (!impl->currentFirstProperty()) { impl->write(",\n"); }
   impl->currentFirstProperty() = false;
   impl->writeIndent();
-  zc::String escapedValue = escapeJsonString(value);
+  zc::String escapedValue = basic::escapeJsonString(value);
   impl->write(zc::str("\"", name, "\": \"", escapedValue, "\""));
 }
 
@@ -230,7 +166,7 @@ void XMLSerializer::writeNodeEnd(const zc::StringPtr nodeType) {
 
 void XMLSerializer::writeProperty(const zc::StringPtr name, const zc::StringPtr value) {
   impl->writeIndent();
-  auto escapedValue = escapeXmlString(value);
+  auto escapedValue = basic::escapeXmlString(value);
   impl->write(zc::str("<", name, ">", escapedValue, "</", name, ">\n"));
 }
 

--- a/products/zomlang/compiler/basic/CMakeLists.txt
+++ b/products/zomlang/compiler/basic/CMakeLists.txt
@@ -1,3 +1,3 @@
-set(BASIC_SRC ${CMAKE_CURRENT_SOURCE_DIR}/frontend.cc ${CMAKE_CURRENT_SOURCE_DIR}/thread-pool.cc ${CMAKE_CURRENT_SOURCE_DIR}/io-utils.cc)
+set(BASIC_SRC ${CMAKE_CURRENT_SOURCE_DIR}/frontend.cc ${CMAKE_CURRENT_SOURCE_DIR}/thread-pool.cc ${CMAKE_CURRENT_SOURCE_DIR}/io-utils.cc ${CMAKE_CURRENT_SOURCE_DIR}/string-escape.cc)
 
 add_library(basic STATIC ${BASIC_SRC})

--- a/products/zomlang/compiler/basic/string-escape.cc
+++ b/products/zomlang/compiler/basic/string-escape.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2024-2025 Zode.Z. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "zomlang/compiler/basic/string-escape.h"
+
+#include "zc/core/string.h"
+#include "zc/core/vector.h"
+
+namespace zomlang {
+namespace compiler {
+namespace basic {
+
+zc::String escapeJsonString(zc::StringPtr str) {
+  zc::Vector<char> result;
+
+  for (char c : str) {
+    switch (c) {
+      case '"':
+        result.addAll("\\\""_zc.asArray());
+        break;
+      case '\\':
+        result.addAll("\\\\"_zc.asArray());
+        break;
+      case '\b':
+        result.addAll("\\b"_zc.asArray());
+        break;
+      case '\f':
+        result.addAll("\\f"_zc.asArray());
+        break;
+      case '\n':
+        result.addAll("\\n"_zc.asArray());
+        break;
+      case '\r':
+        result.addAll("\\r"_zc.asArray());
+        break;
+      case '\t':
+        result.addAll("\\t"_zc.asArray());
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          // Control characters need to be escaped as \uXXXX
+          result.addAll("\\u00"_zc.asArray());
+          result.addAll(zc::hex(static_cast<unsigned char>(c)));
+        } else {
+          result.add(c);
+        }
+        break;
+    }
+  }
+
+  return zc::str(result.asPtr());
+}
+
+zc::String escapeXmlString(zc::StringPtr str) {
+  zc::Vector<char> result;
+
+  for (char c : str) {
+    switch (c) {
+      case '&':
+        result.addAll("&amp;"_zc.asArray());
+        break;
+      case '<':
+        result.addAll("&lt;"_zc.asArray());
+        break;
+      case '>':
+        result.addAll("&gt;"_zc.asArray());
+        break;
+      case '"':
+        result.addAll("&quot;"_zc.asArray());
+        break;
+      case '\'':
+        result.addAll("&apos;"_zc.asArray());
+        break;
+      default:
+        result.add(c);
+        break;
+    }
+  }
+
+  return zc::str(result.asPtr());
+}
+
+}  // namespace basic
+}  // namespace compiler
+}  // namespace zomlang

--- a/products/zomlang/compiler/basic/string-escape.h
+++ b/products/zomlang/compiler/basic/string-escape.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2024-2025 Zode.Z. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+/// \file string-escape.h
+/// \brief String escaping utilities for JSON, XML and other formats
+///
+/// This module provides common string escaping utilities used across the compiler,
+/// including functions for JSON and XML string escaping that comply with their
+/// respective specifications.
+
+#pragma once
+
+#include "zc/core/string.h"
+
+namespace zomlang {
+namespace compiler {
+namespace basic {
+
+/// \brief Escape a string for safe inclusion in JSON
+///
+/// This function escapes special characters in a string to make it safe
+/// for inclusion in JSON output. It handles:
+/// - Quote characters (")
+/// - Backslashes (\)
+/// - Control characters (\n, \r, \t, \b, \f)
+/// - Other control characters (converted to \uXXXX format)
+///
+/// \param str The input string to escape
+/// \return A new string with all necessary characters escaped
+zc::String escapeJsonString(zc::StringPtr str);
+
+/// \brief Escape a string for safe inclusion in XML
+///
+/// This function escapes special characters in a string to make it safe
+/// for inclusion in XML output. It handles:
+/// - Ampersand (&)
+/// - Less than (<)
+/// - Greater than (>)
+/// - Quote characters (")
+/// - Apostrophe (')
+///
+/// \param str The input string to escape
+/// \return A new string with all necessary characters escaped
+zc::String escapeXmlString(zc::StringPtr str);
+
+}  // namespace basic
+}  // namespace compiler
+}  // namespace zomlang

--- a/products/zomlang/compiler/trace/trace.cc
+++ b/products/zomlang/compiler/trace/trace.cc
@@ -18,8 +18,11 @@
 #include <thread>
 
 #include "zc/core/debug.h"
+#include "zc/core/filesystem.h"
 #include "zc/core/map.h"
 #include "zc/core/mutex.h"
+#include "zc/core/vector.h"
+#include "zomlang/compiler/basic/string-escape.h"
 #include "zomlang/compiler/trace/trace-config.h"
 
 namespace zomlang {
@@ -30,7 +33,7 @@ namespace trace {
 // TraceEvent
 
 TraceEvent::TraceEvent(TraceEventType t, TraceCategory cat, zc::StringPtr n, zc::StringPtr d,
-                       uint32_t dep)
+                       uint32_t dep) noexcept
     : type(t), category(cat), name(zc::str(n)), depth(dep) {
   if (d != nullptr) { details = zc::str(d); }
 
@@ -137,10 +140,122 @@ void TraceManager::flush() {
   zc::Locked<zc::Vector<TraceEvent>> lock = impl->events.lockExclusive();
 
   if (impl->config.outputFile != nullptr) {
-    // TODO: Implement file output in JSON format for Chrome tracing
-    // For now, just output to debug log
-    ZC_LOG(INFO, "Trace flush requested - ", lock->size(), " events");
+    ZC_IF_SOME(exception, writeTraceToFile(impl->config.outputFile, *lock)) {
+      ZC_LOG(ERROR, "Failed to write trace file", impl->config.outputFile, exception);
+    }
   }
+}
+
+zc::Maybe<zc::Exception> TraceManager::writeTraceToFile(zc::StringPtr filename,
+                                                        const zc::Vector<TraceEvent>& events) {
+  // Create Chrome tracing JSON format
+  zc::String json = generateChromeTracingJson(events);
+
+  // Write to file using zc::runCatchingExceptions for proper error handling
+  return zc::runCatchingExceptions([&]() {
+    // Use zc filesystem to write the file
+    auto fs = zc::newDiskFilesystem();
+
+    // Use Path::eval to handle both absolute and relative paths correctly
+    zc::Path outputPath = zc::Path(nullptr).eval(filename);
+    auto file = fs->getCurrent().openFile(
+        outputPath, zc::WriteMode::CREATE | zc::WriteMode::MODIFY | zc::WriteMode::CREATE_PARENT);
+    file->writeAll(json);
+    file->datasync();
+  });
+}
+
+zc::String TraceManager::generateChromeTracingJson(const zc::Vector<TraceEvent>& events) {
+  zc::Vector<char> json;
+
+  // Start JSON array
+  json.addAll(zc::StringPtr("{\"traceEvents\":[\n"));
+
+  bool first = true;
+  for (const auto& event : events) {
+    if (!first) { json.addAll(zc::StringPtr(",\n")); }
+    first = false;
+
+    // Convert event to Chrome tracing format
+    zc::String eventJson = formatEventAsJson(event);
+    json.addAll(eventJson);
+  }
+
+  // End JSON
+  json.addAll(zc::StringPtr("\n]}"));
+
+  return zc::str(json.releaseAsArray());
+}
+
+zc::String TraceManager::formatEventAsJson(const TraceEvent& event) {
+  // Map our event types to Chrome tracing format
+  const char* phase;
+  switch (event.type) {
+    case TraceEventType::kEnter:
+      phase = "B";  // Begin
+      break;
+    case TraceEventType::kExit:
+      phase = "E";  // End
+      break;
+    case TraceEventType::kInstant:
+      phase = "i";  // Instant
+      break;
+    case TraceEventType::kCounter:
+      phase = "C";  // Counter
+      break;
+    case TraceEventType::kMetadata:
+      phase = "M";  // Metadata
+      break;
+    default:
+      phase = "i";
+      break;
+  }
+
+  // Convert category to string
+  const char* categoryStr;
+  switch (event.category) {
+    case TraceCategory::kLexer:
+      categoryStr = "lexer";
+      break;
+    case TraceCategory::kParser:
+      categoryStr = "parser";
+      break;
+    case TraceCategory::kChecker:
+      categoryStr = "checker";
+      break;
+    case TraceCategory::kDriver:
+      categoryStr = "driver";
+      break;
+    case TraceCategory::kDiagnostics:
+      categoryStr = "diagnostics";
+      break;
+    case TraceCategory::kMemory:
+      categoryStr = "memory";
+      break;
+    case TraceCategory::kPerformance:
+      categoryStr = "performance";
+      break;
+    default:
+      categoryStr = "unknown";
+      break;
+  }
+
+  // Convert timestamp from nanoseconds to microseconds (Chrome format)
+  uint64_t timestampUs = event.timestamp / 1000;
+
+  // Build JSON object
+  zc::String baseJson =
+      zc::str("  {", "\"name\":\"", basic::escapeJsonString(event.name), "\",", "\"cat\":\"",
+              categoryStr, "\",", "\"ph\":\"", phase, "\",", "\"ts\":", timestampUs, ",",
+              "\"pid\":1,", "\"tid\":", event.threadId);
+
+  // Add details if present
+  if (event.details.size() > 0) {
+    return zc::str(baseJson, ",\"args\":{\"details\":\"", basic::escapeJsonString(event.details),
+                   "\"}}");
+  }
+
+  return zc::str(baseJson, "}");
 }
 
 uint32_t TraceManager::getCurrentDepth() const {
@@ -183,6 +298,11 @@ size_t TraceManager::getEventCount() const {
   return lock->size();
 }
 
+uint32_t TraceManager::getMaxRecursionDepth() const {
+  ZC_REQUIRE(impl.get() != nullptr);
+  return impl->config.maxRecursionDepth;
+}
+
 // ================================================================================
 // Trace functions
 
@@ -220,6 +340,16 @@ struct ScopeTracer::Impl {
 
     if constexpr (kTraceEnabled) {
       if (TraceManager::getInstance().isEnabled(category)) {
+        // Check recursion depth before incrementing
+        uint32_t currentDepth = TraceManager::getInstance().getCurrentDepth();
+        uint32_t maxDepth = TraceManager::getInstance().getMaxRecursionDepth();
+
+        if (currentDepth >= maxDepth) {
+          ZC_FAIL_REQUIRE("Trace recursion depth exceeded maximum limit", currentDepth,
+                          ">=", maxDepth, "category:", static_cast<uint32_t>(category),
+                          "name:", name);
+        }
+
         enabled = true;
         TraceManager::getInstance().incrementDepth();
         TraceManager::getInstance().addEvent(TraceEventType::kEnter, category, name, details);
@@ -240,10 +370,10 @@ struct ScopeTracer::Impl {
 // ================================================================================
 // ScopeTracer
 
-ScopeTracer::ScopeTracer(TraceCategory category, zc::StringPtr name, zc::StringPtr details)
+ScopeTracer::ScopeTracer(TraceCategory category, zc::StringPtr name, zc::StringPtr details) noexcept
     : impl(zc::heap<Impl>(category, name, details)) {}
 
-ScopeTracer::~ScopeTracer() = default;
+ScopeTracer::~ScopeTracer() noexcept(false) = default;
 
 // ================================================================================
 // FunctionTracer::Impl

--- a/products/zomlang/compiler/trace/trace.h
+++ b/products/zomlang/compiler/trace/trace.h
@@ -17,8 +17,10 @@
 #include <cstdint>
 
 #include "zc/core/common.h"
+#include "zc/core/exception.h"
 #include "zc/core/memory.h"
 #include "zc/core/string.h"
+#include "zc/core/vector.h"
 
 namespace zomlang {
 namespace compiler {
@@ -54,6 +56,7 @@ struct TraceConfig {
   bool enableTimestamps = true;
   bool enableThreadInfo = true;
   zc::StringPtr outputFile = nullptr;
+  uint32_t maxRecursionDepth = 1000;  // Maximum recursion depth to prevent stack overflow
 };
 
 /// Individual trace event
@@ -67,7 +70,7 @@ struct TraceEvent {
   uint32_t depth;  // Call stack depth
 
   TraceEvent(TraceEventType t, TraceCategory cat, zc::StringPtr n, zc::StringPtr d = nullptr,
-             uint32_t dep = 0);
+             uint32_t dep = 0) noexcept;
 };
 
 /// Main trace manager - singleton pattern
@@ -101,11 +104,28 @@ public:
   /// Get event count
   size_t getEventCount() const;
 
+  /// Get maximum recursion depth from config
+  uint32_t getMaxRecursionDepth() const;
+
 private:
-  TraceManager() = default;
-  ~TraceManager() = default;
+  TraceManager() noexcept = default;
+  ~TraceManager() noexcept(false) = default;
 
   ZC_DISALLOW_COPY_AND_MOVE(TraceManager);
+
+  /// Write trace events to file in Chrome tracing JSON format
+  /// Returns zc::none on success, or the exception on failure
+  zc::Maybe<zc::Exception> writeTraceToFile(zc::StringPtr filename,
+                                            const zc::Vector<TraceEvent>& events);
+
+  /// Generate Chrome tracing JSON from events
+  zc::String generateChromeTracingJson(const zc::Vector<TraceEvent>& events);
+
+  /// Format single event as JSON
+  zc::String formatEventAsJson(const TraceEvent& event);
+
+  /// Escape string for JSON
+  zc::String escapeJsonString(zc::StringPtr str);
 
   struct Impl;
   zc::Own<Impl> impl;
@@ -120,8 +140,9 @@ void traceCounter(TraceCategory category, zc::StringPtr name, zc::StringPtr deta
 /// Scope tracer with RAII
 class ScopeTracer {
 public:
-  explicit ScopeTracer(TraceCategory category, zc::StringPtr name, zc::StringPtr details = nullptr);
-  ~ScopeTracer();
+  explicit ScopeTracer(TraceCategory category, zc::StringPtr name,
+                       zc::StringPtr details = nullptr) noexcept;
+  ~ScopeTracer() noexcept(false);
 
   ZC_DISALLOW_COPY_AND_MOVE(ScopeTracer);
 

--- a/products/zomlang/tests/unittests/compiler/trace/trace-test.cc
+++ b/products/zomlang/tests/unittests/compiler/trace/trace-test.cc
@@ -16,7 +16,6 @@
 
 #include "zc/core/string.h"
 #include "zc/ztest/test.h"
-#include "zomlang/compiler/trace/trace-config.h"
 
 namespace zomlang {
 namespace compiler {
@@ -79,6 +78,276 @@ ZC_TEST("TraceTest_TraceFlush") {
 
   traceEvent(TraceCategory::kDriver, "flush test");
   TraceManager::getInstance().flush();
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_RecursionDepthLimit") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  config.maxRecursionDepth = 3;  // Set very low limit for testing
+  TraceManager::getInstance().configure(config);
+
+  // Test normal depth tracking
+  {
+    ScopeTracer tracer1(TraceCategory::kParser, "level1");
+    ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 1);
+
+    {
+      ScopeTracer tracer2(TraceCategory::kParser, "level2");
+      ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 2);
+
+      {
+        ScopeTracer tracer3(TraceCategory::kParser, "level3");
+        ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 3);
+      }
+      ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 2);
+    }
+    ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 1);
+  }
+  ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 0);
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_RecursionDepthBoundary") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  config.maxRecursionDepth = 2;  // Set very low limit for testing
+  TraceManager::getInstance().configure(config);
+
+  // Verify the configuration was applied
+  ZC_EXPECT(TraceManager::getInstance().getMaxRecursionDepth() == 2);
+
+  // Test that we can reach exactly the maximum depth
+  {
+    ScopeTracer tracer1(TraceCategory::kParser, "level1");
+    ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 1);
+
+    {
+      ScopeTracer tracer2(TraceCategory::kParser, "level2");
+      ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 2);
+      // At this point we're at the maximum allowed depth
+    }
+    ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 1);
+  }
+  ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 0);
+
+  // Note: We cannot test exceeding the limit because ZC_FAIL_REQUIRE
+  // calls abort() rather than throwing an exception, and ScopeTracer
+  // constructor is noexcept. The depth protection will terminate the
+  // program if exceeded.
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_RecursionDepthConfiguration") {
+  // Test recursion depth configuration and tracking
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+
+  // Test different max recursion depth values
+  config.maxRecursionDepth = 1000;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().getMaxRecursionDepth() == 1000);
+
+  // Change configuration
+  config.maxRecursionDepth = 50;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().getMaxRecursionDepth() == 50);
+
+  // Test depth tracking
+  {
+    ScopeTracer tracer(TraceCategory::kParser, "test");
+    ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 1);
+  }
+  ZC_EXPECT(TraceManager::getInstance().getCurrentDepth() == 0);
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_FileOutput") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  config.outputFile = "/tmp/zom_trace_test.json";
+  TraceManager::getInstance().configure(config);
+
+  // Add some test events
+  traceEvent(TraceCategory::kLexer, "tokenize", "test.zom");
+  traceEvent(TraceCategory::kParser, "parse_expression", "binary_op");
+  traceCounter(TraceCategory::kMemory, "heap_usage", "1024");
+
+  // Test scope tracer
+  {
+    ScopeTracer tracer(TraceCategory::kChecker, "type_check", "function_def");
+    traceEvent(TraceCategory::kDiagnostics, "warning", "unused_variable");
+  }
+
+  // Flush to file
+  TraceManager::getInstance().flush();
+
+  // Verify file was created by checking if we can configure with the same file again
+  // (This is a basic test - in a real scenario we'd read and validate the JSON)
+  TraceConfig verifyConfig;
+  verifyConfig.enabled = true;
+  verifyConfig.outputFile = "/tmp/zom_trace_test.json";
+  TraceManager::getInstance().configure(verifyConfig);
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_JsonStringEscaping") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  config.outputFile = "/tmp/zom_trace_escape_test.json";
+  TraceManager::getInstance().configure(config);
+
+  // Test various characters that need escaping in JSON
+  traceEvent(TraceCategory::kLexer, "test\"quote", "details with \"quotes\"");
+  traceEvent(TraceCategory::kParser, "test\\backslash", "path\\to\\file");
+  traceEvent(TraceCategory::kChecker, "test\nnewline", "line1\nline2");
+  traceEvent(TraceCategory::kDriver, "test\rcarriage", "text\rwith\rcarriage");
+  traceEvent(TraceCategory::kDiagnostics, "test\ttab", "column1\tcolumn2");
+  traceEvent(TraceCategory::kMemory, "mixed\"chars\\test", "quote\"slash\\newline\ntab\t");
+
+  // Verify events were added
+  ZC_EXPECT(TraceManager::getInstance().getEventCount() == 6);
+
+  // Flush to file to trigger JSON generation
+  TraceManager::getInstance().flush();
+
+  // Events should still be present after flush (flush doesn't clear events)
+  ZC_EXPECT(TraceManager::getInstance().getEventCount() == 6);
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_AllTraceCategories") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  config.outputFile = "/tmp/zom_trace_categories_test.json";
+  TraceManager::getInstance().configure(config);
+
+  // Test all trace categories to ensure enum mapping works correctly
+  traceEvent(TraceCategory::kLexer, "lexer_test");
+  traceEvent(TraceCategory::kParser, "parser_test");
+  traceEvent(TraceCategory::kChecker, "checker_test");
+  traceEvent(TraceCategory::kDriver, "driver_test");
+  traceEvent(TraceCategory::kDiagnostics, "diagnostics_test");
+  traceEvent(TraceCategory::kMemory, "memory_test");
+  traceEvent(TraceCategory::kPerformance, "performance_test");
+
+  // Verify all events were added
+  ZC_EXPECT(TraceManager::getInstance().getEventCount() == 7);
+
+  // Flush to file to trigger JSON generation with all categories
+  TraceManager::getInstance().flush();
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_AllTraceEventTypes") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  config.outputFile = "/tmp/zom_trace_event_types_test.json";
+  TraceManager::getInstance().configure(config);
+
+  // Test different event types
+  traceEvent(TraceCategory::kLexer, "instant_event");            // This creates kInstant events
+  traceCounter(TraceCategory::kMemory, "counter_event", "100");  // This creates kCounter events
+
+  // Test scope tracer which creates kEnter and kExit events
+  {
+    ScopeTracer tracer(TraceCategory::kParser, "scope_event");
+    // The tracer will create kEnter on construction and kExit on destruction
+  }
+
+  // Verify events were created (instant + counter + enter + exit = 4 events)
+  ZC_EXPECT(TraceManager::getInstance().getEventCount() >= 4);
+
+  // Flush to file to trigger JSON generation with all event types
+  TraceManager::getInstance().flush();
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_CategoryFiltering_Individual") {
+  // Test individual category filtering to ensure enum values work correctly
+  TraceConfig config;
+  config.enabled = true;
+
+  // Test each category individually
+  config.categoryMask = TraceCategory::kLexer;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kLexer));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kParser));
+
+  config.categoryMask = TraceCategory::kParser;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kParser));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kLexer));
+
+  config.categoryMask = TraceCategory::kChecker;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kChecker));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kParser));
+
+  config.categoryMask = TraceCategory::kDriver;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kDriver));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kChecker));
+
+  config.categoryMask = TraceCategory::kDiagnostics;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kDiagnostics));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kDriver));
+
+  config.categoryMask = TraceCategory::kMemory;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kMemory));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kDiagnostics));
+
+  config.categoryMask = TraceCategory::kPerformance;
+  TraceManager::getInstance().configure(config);
+  ZC_EXPECT(TraceManager::getInstance().isEnabled(TraceCategory::kPerformance));
+  ZC_EXPECT(!TraceManager::getInstance().isEnabled(TraceCategory::kMemory));
+
+  TraceManager::getInstance().clear();
+}
+
+ZC_TEST("TraceTest_EventTypeVariations") {
+  TraceConfig config;
+  config.enabled = true;
+  config.categoryMask = TraceCategory::kAll;
+  TraceManager::getInstance().configure(config);
+
+  // Test instant events (default from traceEvent)
+  traceEvent(TraceCategory::kLexer, "instant_test");
+  size_t countAfterInstant = TraceManager::getInstance().getEventCount();
+  ZC_EXPECT(countAfterInstant == 1);
+
+  // Test counter events
+  traceCounter(TraceCategory::kMemory, "counter_test", "42");
+  size_t countAfterCounter = TraceManager::getInstance().getEventCount();
+  ZC_EXPECT(countAfterCounter == 2);
+
+  // Test scope events (enter + exit)
+  size_t countBeforeScope = TraceManager::getInstance().getEventCount();
+  {
+    ScopeTracer tracer(TraceCategory::kParser, "scope_test");
+    // Should have added enter event
+    ZC_EXPECT(TraceManager::getInstance().getEventCount() == countBeforeScope + 1);
+  }
+  // Should have added exit event
+  ZC_EXPECT(TraceManager::getInstance().getEventCount() == countBeforeScope + 2);
+
   TraceManager::getInstance().clear();
 }
 


### PR DESCRIPTION
- Add maxRecursionDepth config parameter to prevent stack overflow
- Add runtime depth checking in ScopeTracer constructor
- Add noexcept specifications to trace constructors
- Add comprehensive tests for recursion depth limits
- Remove unused trace-config.h include from test file