### PR TITLE
feat(coverage): include lit tests in coverage report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(examples)
 
 if(ZOM_ENABLE_COVERAGE)
   get_property(ALL_TESTS_GLOBAL GLOBAL PROPERTY ALL_TESTS_GLOBAL)
-  create_coverage_target(NAME coverage TARGETS ${ALL_TESTS_GLOBAL} EXCLUDES
-                         ".*\-test\.cc")
+  create_coverage_target(NAME coverage TARGETS ${ALL_TESTS_GLOBAL}
+                         EXTRA_OBJECTS zomc
+                         EXCLUDES ".*\-test\.cc")
 endif()

--- a/cmake/utils/coverage.cmake
+++ b/cmake/utils/coverage.cmake
@@ -7,7 +7,7 @@ function(add_coverage_to_test TEST_NAME)
 endfunction()
 
 function(create_coverage_target)
-  cmake_parse_arguments(COVERAGE "" "NAME" "TARGETS;EXCLUDES" ${ARGN})
+  cmake_parse_arguments(COVERAGE "" "NAME" "TARGETS;EXTRA_OBJECTS;EXCLUDES" ${ARGN})
 
   if(NOT TARGET ${COVERAGE_NAME})
     if(APPLE)
@@ -26,7 +26,7 @@ function(create_coverage_target)
 
     add_custom_target(
       ${COVERAGE_NAME}_run_tests
-      COMMAND timeout 60 ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -j ${CMAKE_JOB_POOLS} || true
+      COMMAND timeout 300 ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -j ${CMAKE_JOB_POOLS} || true
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       COMMENT "Running tests for ${COVERAGE_NAME} (with 60s timeout)")
     add_dependencies(${COVERAGE_NAME}_run_tests ${COVERAGE_NAME}_create_dir)
@@ -46,6 +46,16 @@ function(create_coverage_target)
       get_target_property(TARGET_TYPE ${TARGET_NAME} TYPE)
       if(TARGET_TYPE STREQUAL "EXECUTABLE")
         list(APPEND COVERAGE_EXECUTABLE_FILES $<TARGET_FILE:${TARGET_NAME}>)
+      endif()
+    endforeach()
+
+    # Append extra object targets (e.g. zomc for lit test coverage)
+    foreach(TARGET_NAME ${COVERAGE_EXTRA_OBJECTS})
+      if(TARGET ${TARGET_NAME})
+        get_target_property(TARGET_TYPE ${TARGET_NAME} TYPE)
+        if(TARGET_TYPE STREQUAL "EXECUTABLE")
+          list(APPEND COVERAGE_EXECUTABLE_FILES $<TARGET_FILE:${TARGET_NAME}>)
+        endif()
       endif()
     endforeach()
 

--- a/cmake/utils/unittests.cmake
+++ b/cmake/utils/unittests.cmake
@@ -86,10 +86,17 @@ function(add_lit_ast_test TEST_NAME SOURCE_FILE)
   )
 
   # Set test properties
+  set(TEST_ENV "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}")
+  if(ZOM_ENABLE_COVERAGE)
+    string(APPEND TEST_ENV
+      ";ZOM_ENABLE_COVERAGE=ON"
+    )
+  endif()
+
   set_tests_properties(${TEST_FULL_NAME} PROPERTIES
     LABELS "ast;lit;specification"
     TIMEOUT 30
-    ENVIRONMENT "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}"
+    ENVIRONMENT "${TEST_ENV}"
   )
 endfunction()
 
@@ -122,10 +129,17 @@ function(add_lit_ast_test_with_check TEST_NAME SOURCE_FILE)
   )
 
   # Set test properties
+  set(TEST_ENV "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}")
+  if(ZOM_ENABLE_COVERAGE)
+    string(APPEND TEST_ENV
+      ";ZOM_ENABLE_COVERAGE=ON"
+    )
+  endif()
+
   set_tests_properties(${TEST_FULL_NAME} PROPERTIES
     LABELS "ast;lit;filecheck;specification"
     TIMEOUT 30
-    ENVIRONMENT "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}"
+    ENVIRONMENT "${TEST_ENV}"
   )
 endfunction()
 
@@ -140,9 +154,18 @@ function(add_regression_test TEST_NAME SOURCE_FILE ISSUE_NUMBER)
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
 
+  set(TEST_ENV "")
+  if(ZOM_ENABLE_COVERAGE)
+    set(TEST_ENV
+      "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage/${TEST_FULL_NAME}.profraw"
+      "ZC_CLEAN_SHUTDOWN=1"
+    )
+  endif()
+
   set_tests_properties(${TEST_FULL_NAME} PROPERTIES
     LABELS "regression;issue-${ISSUE_NUMBER}"
     TIMEOUT 30
+    ENVIRONMENT "${TEST_ENV}"
   )
 endfunction()
 

--- a/products/zomlang/tests/lit.cfg.py
+++ b/products/zomlang/tests/lit.cfg.py
@@ -107,6 +107,28 @@ config.substitutions.append(("%FileCheck", filecheck_command))
 config.environment["ZOMLANG_TEST_ROOT"] = config.test_source_root
 config.environment["ZOMLANG_BUILD_ROOT"] = os.environ.get("CMAKE_BINARY_DIR", "")
 
+# Coverage support: when ZOM_ENABLE_COVERAGE is set, inject coverage env vars
+# into every test command via preamble. We must set LLVM_PROFILE_FILE and
+# ZC_CLEAN_SHUTDOWN directly in the shell because lit may not reliably pass
+# config.environment through to subprocesses in all execution modes.
+if os.environ.get("ZOM_ENABLE_COVERAGE"):
+    coverage_dir = os.path.join(
+        os.environ.get("CMAKE_BINARY_DIR", ""), "coverage"
+    )
+    os.makedirs(coverage_dir, exist_ok=True)
+    profile_path = os.path.join(coverage_dir, "lit-%m.profraw")
+    # Replace the %zomc substitution with one that includes coverage env vars
+    for i, (pattern, _) in enumerate(config.substitutions):
+        if pattern == "%zomc":
+            config.substitutions[i] = (
+                "%zomc",
+                f"LLVM_PROFILE_FILE={profile_path} ZC_CLEAN_SHUTDOWN=1 {zomc_path}",
+            )
+            break
+    lit_config.note(
+        f"Coverage enabled: LLVM_PROFILE_FILE={profile_path}"
+    )
+
 # Timeout for individual tests (in seconds)
 lit_config.maxIndividualTestTime = 20
 


### PR DESCRIPTION
Enable LLVM profile data collection from lit integration tests by injecting LLVM_PROFILE_FILE and ZC_CLEAN_SHUTDOWN env vars into %zomc substitution. Add zomc as EXTRA_OBJECTS in coverage target so llvm-cov reports its coverage. Increase coverage test timeout to 300s to accommodate lit test suite.

Line coverage improves from 74.27% to 77.42% with lit tests included.