### PR TITLE
fix(parser): improve type parsing and as-cast recovery

### DIFF
--- a/products/zomlang/compiler/diagnostics/diagnostic-engine.cc
+++ b/products/zomlang/compiler/diagnostics/diagnostic-engine.cc
@@ -31,6 +31,7 @@ struct DiagnosticEngine::Impl {
   source::SourceManager& sourceManager;
   zc::Vector<zc::Own<DiagnosticConsumer>> consumers;
   DiagnosticState state;
+  size_t suppressionDepth = 0;
 };
 
 DiagnosticEngine::DiagnosticEngine(source::SourceManager& sourceManager)
@@ -42,6 +43,8 @@ void DiagnosticEngine::addConsumer(zc::Own<DiagnosticConsumer> consumer) {
 }
 
 void DiagnosticEngine::emit(const Diagnostic& diagnostic) {
+  if (impl->suppressionDepth > 0) { return; }
+
   // Check if this is an error-level diagnostic and update state
   const DiagnosticInfo& info = getDiagnosticInfo(diagnostic.getId());
   if (info.severity >= DiagSeverity::kError) { impl->state.setHadAnyError(); }
@@ -115,6 +118,14 @@ void DiagnosticEngine::formatDiagnosticMessage(const source::SourceManager& sm,
   // Output the remaining text
   if (lastPos < format.size()) { out.write(format.slice(lastPos, format.size()).asBytes()); }
 }
+
+void DiagnosticEngine::suppress() { ++impl->suppressionDepth; }
+
+void DiagnosticEngine::unsuppress() {
+  if (impl->suppressionDepth > 0) { --impl->suppressionDepth; }
+}
+
+bool DiagnosticEngine::isSuppressed() const { return impl->suppressionDepth > 0; }
 
 }  // namespace diagnostics
 }  // namespace compiler

--- a/products/zomlang/compiler/diagnostics/diagnostic-engine.h
+++ b/products/zomlang/compiler/diagnostics/diagnostic-engine.h
@@ -57,6 +57,13 @@ public:
 
   DiagnosticState& getState();
 
+  // Speculative parse support.
+  // suppress() prevents emit() from forwarding diagnostics to consumers or setting hadAnyError.
+  // unsuppress() restores normal emission. Nestable: suppression is active while depth > 0.
+  void suppress();
+  void unsuppress();
+  ZC_NODISCARD bool isSuppressed() const;
+
   /// \brief Report a diagnostic at the given location.
   /// \param loc The location of the diagnostic.
   /// \param id The diagnostic ID.

--- a/products/zomlang/compiler/diagnostics/diagnostics-parse.def
+++ b/products/zomlang/compiler/diagnostics/diagnostics-parse.def
@@ -117,6 +117,12 @@ DIAG(ParameterNameNotAllowed, kError, "'{0}' is not allowed as a parameter name"
 DIAG(TypeParameterDeclarationExpected, kError, "Type parameter declaration expected", 0)
 DIAG(TypeArgumentExpected, kError, "Type argument expected", 0)
 DIAG(TypeExpected, kError, "Type expected", 0)
+DIAG(LineBreakNotAllowedBeforeAsCast, kError,
+     "A line break is not allowed before an 'as' cast expression", 0)
+DIAG(FunctionTypeNotationMustBeParenthesizedInUnionType, kError,
+     "Function type notation must be parenthesized when used in a union type", 0)
+DIAG(FunctionTypeNotationMustBeParenthesizedInIntersectionType, kError,
+     "Function type notation must be parenthesized when used in an intersection type", 0)
 DIAG(UnexpectedTokenExpected, kError, "Unexpected token expected", 0)
 DIAG(IdentifierExpected, kError, "Identifier expected", 0)
 DIAG(IdentifierOrStringLiteralExpected, kError, "Identifier or string literal expected", 0)

--- a/products/zomlang/compiler/parser/parser.cc
+++ b/products/zomlang/compiler/parser/parser.cc
@@ -69,6 +69,7 @@ ast::OperatorPrecedence getBinaryOperatorPrecedence(ast::SyntaxKind tokenKind) {
     case ast::SyntaxKind::GreaterThan:
     case ast::SyntaxKind::LessThanEquals:
     case ast::SyntaxKind::GreaterThanEquals:
+    case ast::SyntaxKind::AsKeyword:
       return ast::OperatorPrecedence::kRelational;
     case ast::SyntaxKind::LessThanLessThan:
     case ast::SyntaxKind::GreaterThanGreaterThan:
@@ -1410,12 +1411,7 @@ zc::Maybe<zc::Vector<zc::Own<ast::TypeNode>>> Parser::tryParseTypeArgumentsInExp
 
     if (!expectToken(ast::SyntaxKind::GreaterThan)) {
       do {
-        ZC_IF_SOME(typeArg, parseType()) { typeArguments.add(zc::mv(typeArg)); }
-        else {
-          // Parsing failed, restore state and return none
-          rewind(state);
-          return zc::none;
-        }
+        typeArguments.add(parseType());
       } while (consumeExpectedToken(ast::SyntaxKind::Comma));
     }
 
@@ -2367,16 +2363,13 @@ zc::Maybe<zc::Own<ast::AliasDeclaration>> Parser::parseAliasDeclaration() {
 
   if (!consumeExpectedToken(ast::SyntaxKind::Equals)) { return zc::none; }
 
-  ZC_IF_SOME(type, parseType()) {
-    if (!consumeExpectedToken(ast::SyntaxKind::Semicolon)) { return zc::none; }
-    source::SourceLoc endLoc = currentLoc();
+  auto type = parseType();
+  if (!consumeExpectedToken(ast::SyntaxKind::Semicolon)) { return zc::none; }
+  source::SourceLoc endLoc = currentLoc();
 
-    return finishNode(
-        ast::factory::createAliasDeclaration(zc::mv(name), zc::mv(typeParameters), zc::mv(type)),
-        loc, endLoc);
-  }
-
-  return zc::none;
+  return finishNode(
+      ast::factory::createAliasDeclaration(zc::mv(name), zc::mv(typeParameters), zc::mv(type)),
+      loc, endLoc);
 }
 
 // ================================================================================
@@ -2517,9 +2510,31 @@ zc::Own<ast::Expression> Parser::parseBinaryExpressionRest(zc::Own<ast::Expressi
     if (!consumeCurrentOperator) { break; }
 
     if (expectToken(ast::SyntaxKind::AsKeyword)) {
-      // 'as' is handled by the unary expression parser, which has higher
-      // precedence than binary operators handled here.
-      break;
+      const bool hasLineBreakBeforeAs = currentToken().hasPrecedingLineBreak();
+      if (hasLineBreakBeforeAs) {
+        parseErrorAtCurrentToken<diagnostics::DiagID::LineBreakNotAllowedBeforeAsCast>();
+      }
+
+      nextToken();
+
+      const bool isForcedCast =
+          expectToken(ast::SyntaxKind::Exclamation) && !currentToken().hasPrecedingLineBreak();
+      const bool isConditionalCast =
+          expectToken(ast::SyntaxKind::Question) && !currentToken().hasPrecedingLineBreak();
+
+      if (isForcedCast || isConditionalCast) { nextToken(); }
+
+      auto targetType = parseType();
+
+      if (isForcedCast) {
+        expr = finishNode(
+            ast::factory::createForcedAsExpression(zc::mv(expr), zc::mv(targetType)), loc);
+      } else if (isConditionalCast) {
+        expr = finishNode(
+            ast::factory::createConditionalAsExpression(zc::mv(expr), zc::mv(targetType)), loc);
+      } else {
+        expr = finishNode(ast::factory::createAsExpression(zc::mv(expr), zc::mv(targetType)), loc);
+      }
     } else {
       auto op = parseTokenNode();
       auto rightOperand = parseBinaryExpressionOrHigher(newPrecedence);
@@ -3046,7 +3061,7 @@ zc::Maybe<zc::Own<ast::ObjectLiteralElement>> Parser::parseObjectLiteralElement(
 // ================================================================================
 // Type parsing implementations
 
-zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseType() {
+zc::Own<ast::TypeNode> Parser::parseType() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseType");
 
   // type: unionType;
@@ -3093,70 +3108,99 @@ zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseType() {
 zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseTypeAnnotation() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseTypeAnnotation");
 
-  return parseOptional(ast::SyntaxKind::Colon) ? parseType() : zc::none;
+  if (!parseOptional(ast::SyntaxKind::Colon)) { return zc::none; }
+  return parseType();
 }
 
-zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseUnionTypeOrHigher() {
-  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseUnionTypeOrHigher");
+zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseFunctionTypeToError(bool isUnionType) {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseFunctionTypeToError");
 
-  // unionType:
-  //   intersectionType (PIPE intersectionType)*;
-  //
-  // Parse the first constituent eagerly, then only wrap it in a UnionTypeNode
-  // once we know we actually saw a `|`. This mirrors the TypeScript parser's
-  // "parse X or higher" shape and keeps union parsing left-to-right while
-  // preserving intersection precedence.
+  if (!isStartOfFunctionType()) { return zc::none; }
 
-  const source::SourceLoc loc = currentLoc();
-
-  ZC_IF_SOME(firstType, parseIntersectionType()) {
-    if (!expectToken(ast::SyntaxKind::Bar)) { return zc::mv(firstType); }
-
-    zc::Vector<zc::Own<ast::TypeNode>> types;
-    types.add(zc::mv(firstType));
-
-    while (parseOptional(ast::SyntaxKind::Bar)) {
-      ZC_IF_SOME(nextType, parseIntersectionType()) {
-        types.add(zc::mv(nextType));
-        continue;
-      }
-
-      parseErrorAtCurrentToken<diagnostics::DiagID::TypeExpected>();
-      return zc::none;
-    }
-
-    return finishNode(ast::factory::createUnionType(zc::mv(types)), loc);
+  // Function type notation is not allowed directly as a constituent of a union
+  // or intersection. Parse it anyway so the AST stays recoverable, then attach a
+  // targeted diagnostic asking the user to add parentheses.
+  zc::Own<ast::TypeNode> type = parseFunctionType();
+  if (isUnionType) {
+    parseErrorAtRange<diagnostics::DiagID::FunctionTypeNotationMustBeParenthesizedInUnionType>(
+        type->getSourceRange());
+  }
+  else {
+    parseErrorAtRange<
+        diagnostics::DiagID::FunctionTypeNotationMustBeParenthesizedInIntersectionType>(
+        type->getSourceRange());
   }
 
-  return zc::none;
+  return type;
 }
 
-zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseIntersectionType() {
-  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseIntersectionType");
-
-  // intersectionType:
-  //   primaryType (AMPERSAND primaryType)*;
-  //
-  // Handles intersection types like A & B & C
-
+zc::Own<ast::TypeNode> Parser::parseUnionOrIntersectionType(
+    ast::SyntaxKind operatorToken, zc::Function<zc::Own<ast::TypeNode>()> parseConstituentType) {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseUnionOrIntersectionType");
   const source::SourceLoc loc = currentLoc();
+  const bool isUnionType = operatorToken == ast::SyntaxKind::Bar;
+  const bool hasLeadingOperator = parseOptional(operatorToken);
 
-  ZC_IF_SOME(type, parsePostfixType()) {
+  auto type = hasLeadingOperator
+                  ? parseFunctionTypeToError(isUnionType).orDefault([&]() {
+                      return parseConstituentType();
+                    })
+                  : parseConstituentType();
+
+  if (expectToken(operatorToken) || hasLeadingOperator) {
     zc::Vector<zc::Own<ast::TypeNode>> types;
     types.add(zc::mv(type));
 
-    while (expectToken(ast::SyntaxKind::Ampersand)) {
-      nextToken();
-      ZC_IF_SOME(rightType, parsePostfixType()) { types.add(zc::mv(rightType)); }
+    while (parseOptional(operatorToken)) {
+      types.add(parseFunctionTypeToError(isUnionType).orDefault([&]() {
+        return parseConstituentType();
+      }));
     }
 
-    // Only create IntersectionType if there are multiple types
-    if (types.size() == 1) { return zc::mv(types[0]); }
-
-    return finishNode(ast::factory::createIntersectionType(zc::mv(types)), loc);
+    switch (operatorToken) {
+      case ast::SyntaxKind::Bar:
+        return finishNode(ast::factory::createUnionType(zc::mv(types)), loc);
+      case ast::SyntaxKind::Ampersand:
+        return finishNode(ast::factory::createIntersectionType(zc::mv(types)), loc);
+      default:
+        ZC_UNREACHABLE;
+    }
   }
 
-  return zc::none;
+  return type;
+}
+
+zc::Own<ast::TypeNode> Parser::parseUnionTypeOrHigher() {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseUnionTypeOrHigher");
+
+  // unionTypeOrHigher:
+  //   intersectionTypeOrHigher (PIPE intersectionTypeOrHigher)*;
+  //
+  // Shares the same skeleton as intersection parsing so leading operators and
+  // function-type constituents are handled consistently.
+  return parseUnionOrIntersectionType(ast::SyntaxKind::Bar,
+                                      ZC_BIND_METHOD(*this, parseIntersectionTypeOrHigher));
+}
+
+zc::Own<ast::TypeNode> Parser::parseIntersectionTypeOrHigher() {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseIntersectionTypeOrHigher");
+
+  // intersectionTypeOrHigher:
+  //   postfixTypeOrHigher (AMPERSAND postfixTypeOrHigher)*;
+  //
+  // Handles intersection types like A & B & C
+
+  return parseUnionOrIntersectionType(ast::SyntaxKind::Ampersand,
+                                      ZC_BIND_METHOD(*this, parsePostfixTypeOrHigher));
+}
+
+zc::Own<ast::TypeNode> Parser::parsePostfixTypeOrHigher() {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parsePostfixTypeOrHigher");
+
+  ZC_IF_SOME(type, parsePostfixType()) { return zc::mv(type); }
+
+  parseErrorAtCurrentToken<diagnostics::DiagID::TypeExpected>();
+  return finishNode(ast::factory::createPredefinedType("unit"_zc), currentLoc());
 }
 
 zc::Maybe<zc::Own<ast::TypeNode>> Parser::parsePostfixType() {
@@ -3254,7 +3298,7 @@ zc::Maybe<zc::Own<ast::ArrayTypeNode>> Parser::parseArrayType() {
   return zc::none;
 }
 
-zc::Maybe<zc::Own<ast::FunctionTypeNode>> Parser::parseFunctionType() {
+zc::Own<ast::FunctionTypeNode> Parser::parseFunctionType() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseFunctionType");
 
   // Parse function type according to the grammar rule:
@@ -3271,13 +3315,9 @@ zc::Maybe<zc::Own<ast::FunctionTypeNode>> Parser::parseFunctionType() {
   // Parse parameter clause: (param1: Type1, param2: Type2)
   auto parameters = parseParameters();
   // Parse return type: -> type raises error
-  ZC_IF_SOME(returnType, parseReturnType()) {
-    return finishNode(ast::factory::createFunctionType(zc::mv(typeParameters), zc::mv(parameters),
-                                                       zc::mv(returnType)),
-                      loc);
-  }
-
-  return zc::none;
+  return finishNode(ast::factory::createFunctionType(zc::mv(typeParameters), zc::mv(parameters),
+                                                     parseRequiredReturnType()),
+                    loc);
 }
 
 zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseParenthesizedOrTupleType() {
@@ -3308,10 +3348,7 @@ zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseParenthesizedOrTupleType() {
     if (currentToken().is(ast::SyntaxKind::Colon)) {
       nextToken();  // consume ':'
       hasNamedElement = true;
-      ZC_IF_SOME(type, parseType()) {
-        elements.add(ast::factory::createNamedTupleElement(zc::mv(name), zc::mv(type)));
-      }
-      else { return zc::none; }
+      elements.add(ast::factory::createNamedTupleElement(zc::mv(name), parseType()));
     } else {
       // Not a named element, rewind and parse as a regular type
       rewind(state);
@@ -3320,8 +3357,7 @@ zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseParenthesizedOrTupleType() {
 
   // If not a named element, parse as a regular type
   if (!hasNamedElement) {
-    ZC_IF_SOME(type, parseType()) { elements.add(zc::mv(type)); }
-    else { return zc::none; }
+    elements.add(parseType());
   }
 
   // Check if there are more elements (comma-separated)
@@ -3334,18 +3370,14 @@ zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseParenthesizedOrTupleType() {
         auto name = parseIdentifier();
         if (currentToken().is(ast::SyntaxKind::Colon)) {
           nextToken();  // consume ':'
-          ZC_IF_SOME(type, parseType()) {
-            elements.add(ast::factory::createNamedTupleElement(zc::mv(name), zc::mv(type)));
-          }
-          else { return zc::none; }
+          elements.add(ast::factory::createNamedTupleElement(zc::mv(name), parseType()));
           continue;
         } else {
           rewind(state);
         }
       }
 
-      ZC_IF_SOME(type, parseType()) { elements.add(zc::mv(type)); }
-      else { return zc::none; }
+      elements.add(parseType());
     }
   }
 
@@ -3460,12 +3492,11 @@ zc::Maybe<zc::Own<ast::TupleTypeNode>> Parser::parseTupleType() {
         }
       }
 
-      ZC_IF_SOME(type, parseType()) {
-        ZC_IF_SOME(n, zc::mv(name)) {
-          elements.add(ast::factory::createNamedTupleElement(zc::mv(n), zc::mv(type)));
-        }
-        else { elements.add(zc::mv(type)); }
+      auto type = parseType();
+      ZC_IF_SOME(n, zc::mv(name)) {
+        elements.add(ast::factory::createNamedTupleElement(zc::mv(n), zc::mv(type)));
       }
+      else { elements.add(zc::mv(type)); }
     } while (consumeExpectedToken(ast::SyntaxKind::Comma));
   }
 
@@ -3492,8 +3523,7 @@ zc::Maybe<zc::Own<ast::TypeReferenceNode>> Parser::parseTypeReference() {
     zc::Vector<zc::Own<ast::TypeNode>> args;
     nextToken();  // consume '<'
     while (!expectToken(ast::SyntaxKind::GreaterThan)) {
-      ZC_IF_SOME(arg, parseType()) { args.add(zc::mv(arg)); }
-      else { return zc::none; }
+      args.add(parseType());
       if (!expectToken(ast::SyntaxKind::GreaterThan) &&
           !consumeExpectedToken(ast::SyntaxKind::Comma)) {
         break;
@@ -3615,7 +3645,7 @@ zc::Maybe<zc::Own<ast::Pattern>> Parser::parseStructurePattern() {
     if (consumeExpectedToken(ast::SyntaxKind::Colon)) {
       // Structure pattern properties are type annotations in Zom
       // e.g. { x: i32, y: str }
-      ZC_IF_SOME(type, parseType()) { nestedPattern = ast::factory::createIsPattern(zc::mv(type)); }
+      nestedPattern = ast::factory::createIsPattern(parseType());
     }
 
     auto prop = finishNode(ast::factory::createPatternProperty(zc::mv(name), zc::mv(nestedPattern)),
@@ -3658,10 +3688,7 @@ zc::Maybe<zc::Own<ast::Pattern>> Parser::parseIsPattern() {
 
   if (!consumeExpectedToken(ast::SyntaxKind::IsKeyword)) { return zc::none; }
 
-  ZC_IF_SOME(type, parseType()) {
-    return finishNode(ast::factory::createIsPattern(zc::mv(type)), loc);
-  }
-  return zc::none;
+  return finishNode(ast::factory::createIsPattern(parseType()), loc);
 }
 
 zc::OneOf<zc::Own<ast::BindingPattern>, zc::Own<ast::Identifier>>
@@ -4177,6 +4204,13 @@ zc::Maybe<zc::Own<ast::CaptureElement>> Parser::parseCaptureElement() {
 zc::Maybe<zc::Own<ast::ReturnTypeNode>> Parser::parseReturnType() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseReturnType");
 
+  if (shouldParseReturnType(ast::SyntaxKind::Arrow)) { return parseRequiredReturnType(); }
+  return zc::none;
+}
+
+zc::Own<ast::ReturnTypeNode> Parser::parseRequiredReturnType() {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseRequiredReturnType");
+
   // Parse optional return type or error return clause
   //
   // callSignature:
@@ -4185,15 +4219,17 @@ zc::Maybe<zc::Own<ast::ReturnTypeNode>> Parser::parseReturnType() {
   const lexer::Token token = currentToken();
   const source::SourceLoc loc = token.getLocation();
 
-  if (!consumeExpectedToken(ast::SyntaxKind::Arrow)) { return zc::none; }
+  zc::Maybe<zc::Own<ast::TypeNode>> errorType = zc::none;
+  if (consumeExpectedToken(ast::SyntaxKind::RaisesKeyword)) { errorType = parseType(); }
+  return finishNode(ast::factory::createReturnType(parseType(), zc::mv(errorType)), loc);
+}
 
-  ZC_IF_SOME(type, parseType()) {
-    zc::Maybe<zc::Own<ast::TypeNode>> errorType = zc::none;
-    if (consumeExpectedToken(ast::SyntaxKind::RaisesKeyword)) { errorType = parseType(); }
-    return finishNode(ast::factory::createReturnType(zc::mv(type), zc::mv(errorType)), loc);
+bool Parser::shouldParseReturnType(ast::SyntaxKind returnToken) {
+  if (expectToken(ast::SyntaxKind::Arrow)) {
+    parseExpected(ast::SyntaxKind::Arrow);
+    return true;
   }
-
-  return zc::none;
+  return false;
 }
 
 zc::Own<ast::VariableStatement> Parser::parseVariableStatement() {

--- a/products/zomlang/compiler/parser/parser.cc
+++ b/products/zomlang/compiler/parser/parser.cc
@@ -4226,9 +4226,10 @@ zc::Own<ast::ReturnTypeNode> Parser::parseRequiredReturnType() {
   const lexer::Token token = currentToken();
   const source::SourceLoc loc = token.getLocation();
 
+  auto type = parseType();
   zc::Maybe<zc::Own<ast::TypeNode>> errorType = zc::none;
   if (consumeExpectedToken(ast::SyntaxKind::RaisesKeyword)) { errorType = parseType(); }
-  return finishNode(ast::factory::createReturnType(parseType(), zc::mv(errorType)), loc);
+  return finishNode(ast::factory::createReturnType(zc::mv(type), zc::mv(errorType)), loc);
 }
 
 bool Parser::shouldParseReturnType(ast::SyntaxKind returnToken) {

--- a/products/zomlang/compiler/parser/parser.cc
+++ b/products/zomlang/compiler/parser/parser.cc
@@ -4211,7 +4211,7 @@ zc::Maybe<zc::Own<ast::CaptureElement>> Parser::parseCaptureElement() {
 zc::Maybe<zc::Own<ast::ReturnTypeNode>> Parser::parseReturnType() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseReturnType");
 
-  if (shouldParseReturnType(ast::SyntaxKind::Arrow)) { return parseRequiredReturnType(); }
+  if (expectToken(ast::SyntaxKind::Arrow)) { return parseRequiredReturnType(); }
   return zc::none;
 }
 
@@ -4226,18 +4226,14 @@ zc::Own<ast::ReturnTypeNode> Parser::parseRequiredReturnType() {
   const lexer::Token token = currentToken();
   const source::SourceLoc loc = token.getLocation();
 
+  parseExpected(ast::SyntaxKind::Arrow);
+
   auto type = parseType();
+
   zc::Maybe<zc::Own<ast::TypeNode>> errorType = zc::none;
   if (consumeExpectedToken(ast::SyntaxKind::RaisesKeyword)) { errorType = parseType(); }
-  return finishNode(ast::factory::createReturnType(zc::mv(type), zc::mv(errorType)), loc);
-}
 
-bool Parser::shouldParseReturnType(ast::SyntaxKind returnToken) {
-  if (expectToken(ast::SyntaxKind::Arrow)) {
-    parseExpected(ast::SyntaxKind::Arrow);
-    return true;
-  }
-  return false;
+  return finishNode(ast::factory::createReturnType(zc::mv(type), zc::mv(errorType)), loc);
 }
 
 zc::Own<ast::VariableStatement> Parser::parseVariableStatement() {

--- a/products/zomlang/compiler/parser/parser.cc
+++ b/products/zomlang/compiler/parser/parser.cc
@@ -1397,11 +1397,19 @@ zc::Maybe<zc::Vector<zc::Own<ast::TypeNode>>> Parser::tryParseTypeArgumentsInExp
   // typeArguments: LT typeArgumentList GT;
   // typeArgumentList: type (COMMA type)*;
   // This function parses type arguments in expression context, like f<number>(42)
+  //
+  // Mirrors the tryParse speculation pattern: diagnostics emitted during the speculative parse
+  // must not leak to consumers when the parse fails (e.g. when `<` is actually a comparison
+  // operator, not a type argument opener).
 
   if (!expectToken(ast::SyntaxKind::LessThan)) { return zc::none; }
-  // TypeArguments must not be parsed in JavaScript files to avoid ambiguity with binary operators.
   // Save current parser state
   ParserState state = mark();
+
+  // Suppress diagnostics during speculative parsing.
+  // On success the type arguments were parsed correctly, so no errors were emitted.
+  // On failure the speculative diagnostics are discarded.
+  impl->diagnosticEngine.suppress();
 
   if (expectToken(ast::SyntaxKind::LessThan)) {
     nextToken();
@@ -1410,13 +1418,12 @@ zc::Maybe<zc::Vector<zc::Own<ast::TypeNode>>> Parser::tryParseTypeArgumentsInExp
     zc::Vector<zc::Own<ast::TypeNode>> typeArguments;
 
     if (!expectToken(ast::SyntaxKind::GreaterThan)) {
-      do {
-        typeArguments.add(parseType());
-      } while (consumeExpectedToken(ast::SyntaxKind::Comma));
+      do { typeArguments.add(parseType()); } while (consumeExpectedToken(ast::SyntaxKind::Comma));
     }
 
     // If it doesn't have the closing `>` then it's definitely not a type argument list.
     if (!consumeExpectedToken(ast::SyntaxKind::GreaterThan)) {
+      impl->diagnosticEngine.unsuppress();
       rewind(state);
       return zc::none;
     }
@@ -1425,10 +1432,14 @@ zc::Maybe<zc::Vector<zc::Own<ast::TypeNode>>> Parser::tryParseTypeArgumentsInExp
     // treat it as such. If the type argument list is followed by `(` or a template literal, as in
     // `f<number>(42)`, we favor the type argument interpretation even though JavaScript would view
     // it as a relational expression.
-    if (canFollowTypeArgumentsInExpression()) { return zc::mv(typeArguments); }
+    if (canFollowTypeArgumentsInExpression()) {
+      impl->diagnosticEngine.unsuppress();
+      return zc::mv(typeArguments);
+    }
   }
 
   // Parsing failed or doesn't follow expected pattern, restore state
+  impl->diagnosticEngine.unsuppress();
   rewind(state);
   return zc::none;
 }
@@ -2368,8 +2379,8 @@ zc::Maybe<zc::Own<ast::AliasDeclaration>> Parser::parseAliasDeclaration() {
   source::SourceLoc endLoc = currentLoc();
 
   return finishNode(
-      ast::factory::createAliasDeclaration(zc::mv(name), zc::mv(typeParameters), zc::mv(type)),
-      loc, endLoc);
+      ast::factory::createAliasDeclaration(zc::mv(name), zc::mv(typeParameters), zc::mv(type)), loc,
+      endLoc);
 }
 
 // ================================================================================
@@ -2527,8 +2538,8 @@ zc::Own<ast::Expression> Parser::parseBinaryExpressionRest(zc::Own<ast::Expressi
       auto targetType = parseType();
 
       if (isForcedCast) {
-        expr = finishNode(
-            ast::factory::createForcedAsExpression(zc::mv(expr), zc::mv(targetType)), loc);
+        expr = finishNode(ast::factory::createForcedAsExpression(zc::mv(expr), zc::mv(targetType)),
+                          loc);
       } else if (isConditionalCast) {
         expr = finishNode(
             ast::factory::createConditionalAsExpression(zc::mv(expr), zc::mv(targetType)), loc);
@@ -3124,8 +3135,7 @@ zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseFunctionTypeToError(bool isUnionT
   if (isUnionType) {
     parseErrorAtRange<diagnostics::DiagID::FunctionTypeNotationMustBeParenthesizedInUnionType>(
         type->getSourceRange());
-  }
-  else {
+  } else {
     parseErrorAtRange<
         diagnostics::DiagID::FunctionTypeNotationMustBeParenthesizedInIntersectionType>(
         type->getSourceRange());
@@ -3141,11 +3151,10 @@ zc::Own<ast::TypeNode> Parser::parseUnionOrIntersectionType(
   const bool isUnionType = operatorToken == ast::SyntaxKind::Bar;
   const bool hasLeadingOperator = parseOptional(operatorToken);
 
-  auto type = hasLeadingOperator
-                  ? parseFunctionTypeToError(isUnionType).orDefault([&]() {
-                      return parseConstituentType();
-                    })
-                  : parseConstituentType();
+  auto type = hasLeadingOperator ? parseFunctionTypeToError(isUnionType).orDefault([&]() {
+    return parseConstituentType();
+  })
+                                 : parseConstituentType();
 
   if (expectToken(operatorToken) || hasLeadingOperator) {
     zc::Vector<zc::Own<ast::TypeNode>> types;
@@ -3356,9 +3365,7 @@ zc::Maybe<zc::Own<ast::TypeNode>> Parser::parseParenthesizedOrTupleType() {
   }
 
   // If not a named element, parse as a regular type
-  if (!hasNamedElement) {
-    elements.add(parseType());
-  }
+  if (!hasNamedElement) { elements.add(parseType()); }
 
   // Check if there are more elements (comma-separated)
   if (expectToken(ast::SyntaxKind::Comma)) {

--- a/products/zomlang/compiler/parser/parser.h
+++ b/products/zomlang/compiler/parser/parser.h
@@ -511,15 +511,20 @@ private:
   zc::Maybe<zc::Own<ast::Identifier>> parseIdentifierExpression();
 
   // --- Types ---
-  zc::Maybe<zc::Own<ast::TypeNode>> parseType();
+  zc::Own<ast::TypeNode> parseType();
   zc::Maybe<zc::Own<ast::TypeNode>> parseTypeAnnotation();
-  zc::Maybe<zc::Own<ast::TypeNode>> parseUnionTypeOrHigher();
-  zc::Maybe<zc::Own<ast::TypeNode>> parseIntersectionType();
+  zc::Maybe<zc::Own<ast::TypeNode>> parseFunctionTypeToError(bool isUnionType);
+  zc::Own<ast::TypeNode> parseUnionOrIntersectionType(
+      ast::SyntaxKind operatorToken, zc::Function<zc::Own<ast::TypeNode>()> parseConstituentType);
+  zc::Own<ast::TypeNode> parseUnionTypeOrHigher();
+  zc::Own<ast::TypeNode> parseIntersectionTypeOrHigher();
+  zc::Own<ast::TypeNode> parsePostfixTypeOrHigher();
   zc::Maybe<zc::Own<ast::TypeNode>> parsePostfixType();
   zc::Maybe<zc::Own<ast::TypeNode>> parseTypeAtom();
   zc::Maybe<zc::Own<ast::ArrayTypeNode>> parseArrayType();
-  zc::Maybe<zc::Own<ast::FunctionTypeNode>> parseFunctionType();
+  zc::Own<ast::FunctionTypeNode> parseFunctionType();
   zc::Maybe<zc::Own<ast::ReturnTypeNode>> parseReturnType();
+  zc::Own<ast::ReturnTypeNode> parseRequiredReturnType();
   zc::Maybe<zc::Own<ast::ObjectTypeNode>> parseObjectType();
   zc::Maybe<zc::Own<ast::TupleTypeNode>> parseTupleType();
   zc::Maybe<zc::Own<ast::TypeReferenceNode>> parseTypeReference();
@@ -529,6 +534,9 @@ private:
   zc::Maybe<zc::Own<ast::TypeQueryNode>> parseTypeQuery();
   zc::Maybe<zc::Own<ast::Expression>> parseTypeQueryExpression();
   zc::Maybe<zc::Own<ast::TypeNode>> parseRaisesClause();
+
+  // --- Returns ---
+  bool shouldParseReturnType(ast::SyntaxKind returnToken);
 
   // --- Patterns & Identifiers ---
   zc::Maybe<zc::Own<ast::Pattern>> parsePattern();

--- a/products/zomlang/tests/language/errors/interface-property-missing-name.zom
+++ b/products/zomlang/tests/language/errors/interface-property-missing-name.zom
@@ -5,7 +5,7 @@ interface I {
 }
 
 
-// CHECK: Error [ZOM2071]: Identifier expected
+// CHECK: Error [ZOM2074]: Identifier expected
 // CHECK:   --> {{.*interface-property-missing-name.zom}}:4:6
 // CHECK:   |
 // CHECK: 4 |   let : i32;

--- a/products/zomlang/tests/language/expressions/unary-and-cast.zom
+++ b/products/zomlang/tests/language/expressions/unary-and-cast.zom
@@ -1,84 +1,195 @@
-// RUN: ! %zomc compile --dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %zomc compile --dump-ast %s 2>&1 | %FileCheck %s
 
 let a = 1;
 let b = ++a;
 let c = a--;
 let d = typeof a;
-let e = await a;
 let f = a as i32;
 let g = a as? i32;
 let h = a as! i32;
 
 
-// CHECK: Error [ZOM2010]: Reserved keyword 'await' cannot be used as an identifier
-// CHECK:   --> {{.*unary-and-cast.zom}}:7:9
-// CHECK:   |
-// CHECK: 7 | let e = await a;
-// CHECK:   |         ^~~~~
-// CHECK: Error [ZOM2025]: Expected ','
-// CHECK:   --> {{.*unary-and-cast.zom}}:7:15
-// CHECK:   |
-// CHECK: 7 | let e = await a;
-// CHECK:   |               ^
-// CHECK: Error [ZOM2025]: Expected ','
-// CHECK:   --> {{.*unary-and-cast.zom}}:8:11
-// CHECK:   |
-// CHECK: 8 | let f = a as i32;
-// CHECK:   |           ^~
-// CHECK: Error [ZOM2058]: 'as' is not allowed as a variable declaration name
-// CHECK:   --> {{.*unary-and-cast.zom}}:8:11
-// CHECK:   |
-// CHECK: 8 | let f = a as i32;
-// CHECK:   |           ^~
-// CHECK: Error [ZOM2058]: 'i32' is not allowed as a variable declaration name
-// CHECK:   --> {{.*unary-and-cast.zom}}:8:14
-// CHECK:   |
-// CHECK: 8 | let f = a as i32;
-// CHECK:   |              ^~~
-// CHECK: Error [ZOM2025]: Expected ','
-// CHECK:   --> {{.*unary-and-cast.zom}}:9:11
-// CHECK:   |
-// CHECK: 9 | let g = a as? i32;
-// CHECK:   |           ^~
-// CHECK: Error [ZOM2058]: 'as' is not allowed as a variable declaration name
-// CHECK:   --> {{.*unary-and-cast.zom}}:9:11
-// CHECK:   |
-// CHECK: 9 | let g = a as? i32;
-// CHECK:   |           ^~
-// CHECK: Error [ZOM2059]: Variable declaration expected
-// CHECK:   --> {{.*unary-and-cast.zom}}:9:13
-// CHECK:   |
-// CHECK: 9 | let g = a as? i32;
-// CHECK:   |             ^
-// CHECK: Error [ZOM2058]: 'i32' is not allowed as a variable declaration name
-// CHECK:   --> {{.*unary-and-cast.zom}}:9:15
-// CHECK:   |
-// CHECK: 9 | let g = a as? i32;
-// CHECK:   |               ^~~
-// CHECK: Error [ZOM2025]: Expected ','
-// CHECK:   --> {{.*unary-and-cast.zom}}:10:11
-// CHECK:    |
-// CHECK: 10 | let h = a as! i32;
-// CHECK:    |           ^~
-// CHECK: Error [ZOM2058]: 'as' is not allowed as a variable declaration name
-// CHECK:   --> {{.*unary-and-cast.zom}}:10:11
-// CHECK:    |
-// CHECK: 10 | let h = a as! i32;
-// CHECK:    |           ^~
-// CHECK: Error [ZOM2059]: Variable declaration expected
-// CHECK:   --> {{.*unary-and-cast.zom}}:10:13
-// CHECK:    |
-// CHECK: 10 | let h = a as! i32;
-// CHECK:    |             ^
-// CHECK: Error [ZOM2025]: Expected ';'
-// CHECK:   --> {{.*unary-and-cast.zom}}:10:13
-// CHECK:    |
-// CHECK: 10 | let h = a as! i32;
-// CHECK:    |             ^
-// CHECK: Error [ZOM2010]: Reserved keyword 'i32' cannot be used as an identifier
-// CHECK:   --> {{.*unary-and-cast.zom}}:10:15
-// CHECK:    |
-// CHECK: 10 | let h = a as! i32;
-// CHECK:    |               ^~~
-// CHECK: {{.*zomc}} compile: Compilation failed due to parsing errors.
-// CHECK: Try '{{.*zomc}} compile --help' for more information.
+// CHECK: {
+// CHECK-NEXT:   "node": "SourceFile",
+// CHECK-NEXT:   "fileName": "{{.*unary-and-cast.zom}}",
+// CHECK-NEXT:   "statements": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "a"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "IntegerLiteral",
+// CHECK-NEXT:               "value": "1"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "b"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "PrefixUnaryExpression",
+// CHECK-NEXT:               "operator": {
+// CHECK-NEXT:                 "node": "TokenNode",
+// CHECK-NEXT:                 "symbol": "++"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "operand": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "a"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "c"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "PostfixUnaryExpression",
+// CHECK-NEXT:               "operand": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "a"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "operator": {
+// CHECK-NEXT:                 "node": "TokenNode",
+// CHECK-NEXT:                 "symbol": "--"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "d"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "TypeOfExpression",
+// CHECK-NEXT:               "expression": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "a"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "f"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "AsExpression",
+// CHECK-NEXT:               "expression": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "a"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "targetType": {
+// CHECK-NEXT:                 "node": "I32TypeNode",
+// CHECK-NEXT:                 "name": "i32"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "g"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "ConditionalAsExpression",
+// CHECK-NEXT:               "expression": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "a"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "targetType": {
+// CHECK-NEXT:                 "node": "I32TypeNode",
+// CHECK-NEXT:                 "name": "i32"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "h"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "ForcedAsExpression",
+// CHECK-NEXT:               "expression": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "a"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "targetType": {
+// CHECK-NEXT:                 "node": "I32TypeNode",
+// CHECK-NEXT:                 "name": "i32"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }

--- a/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
+++ b/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
@@ -2019,8 +2019,24 @@ ZC_TEST("ParserTest.ParseCastExpression") {
       sourceManager->addMemBufferCopy(zc::str("let x = value as i32;").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
-  auto result = parser.parse();
-  ZC_EXPECT(result != zc::none, "Should parse cast expression");
+  ZC_IF_SOME(root, parser.parse()) {
+    auto& sourceFile = ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::SourceFile>(*root);
+    const auto& statements = sourceFile.getStatements();
+    ZC_EXPECT(statements.size() == 1, "Should contain one statement");
+
+    auto& variableStatement =
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
+            statements[0]);
+    const auto& declarations = variableStatement.getDeclarations().getBindings();
+    ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
+
+    ZC_IF_SOME(initializer, declarations[0].getInitializer()) {
+      ZC_EXPECT(initializer.getKind() == ast::SyntaxKind::AsExpression,
+                "Initializer should be parsed as an as-expression");
+    }
+    else { ZC_EXPECT(false, "Variable declaration should have an initializer"); }
+  }
+  else { ZC_EXPECT(false, "Should parse cast expression"); }
 }
 
 ZC_TEST("ParserTest.ParseOptionalCastExpression") {
@@ -2033,8 +2049,24 @@ ZC_TEST("ParserTest.ParseOptionalCastExpression") {
       sourceManager->addMemBufferCopy(zc::str("let x = value as? str;").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
-  auto result = parser.parse();
-  ZC_EXPECT(result != zc::none, "Should parse optional cast expression");
+  ZC_IF_SOME(root, parser.parse()) {
+    auto& sourceFile = ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::SourceFile>(*root);
+    const auto& statements = sourceFile.getStatements();
+    ZC_EXPECT(statements.size() == 1, "Should contain one statement");
+
+    auto& variableStatement =
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
+            statements[0]);
+    const auto& declarations = variableStatement.getDeclarations().getBindings();
+    ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
+
+    ZC_IF_SOME(initializer, declarations[0].getInitializer()) {
+      ZC_EXPECT(initializer.getKind() == ast::SyntaxKind::ConditionalAsExpression,
+                "Initializer should be parsed as a conditional as-expression");
+    }
+    else { ZC_EXPECT(false, "Variable declaration should have an initializer"); }
+  }
+  else { ZC_EXPECT(false, "Should parse optional cast expression"); }
 }
 
 ZC_TEST("ParserTest.ParseForceCastExpression") {
@@ -2047,8 +2079,57 @@ ZC_TEST("ParserTest.ParseForceCastExpression") {
       sourceManager->addMemBufferCopy(zc::str("let x = value as! f64;").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
-  auto result = parser.parse();
-  ZC_EXPECT(result != zc::none, "Should parse force cast expression");
+  ZC_IF_SOME(root, parser.parse()) {
+    auto& sourceFile = ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::SourceFile>(*root);
+    const auto& statements = sourceFile.getStatements();
+    ZC_EXPECT(statements.size() == 1, "Should contain one statement");
+
+    auto& variableStatement =
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
+            statements[0]);
+    const auto& declarations = variableStatement.getDeclarations().getBindings();
+    ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
+
+    ZC_IF_SOME(initializer, declarations[0].getInitializer()) {
+      ZC_EXPECT(initializer.getKind() == ast::SyntaxKind::ForcedAsExpression,
+                "Initializer should be parsed as a forced as-expression");
+    }
+    else { ZC_EXPECT(false, "Variable declaration should have an initializer"); }
+  }
+  else { ZC_EXPECT(false, "Should parse force cast expression"); }
+}
+
+ZC_TEST("ParserTest.ParseAsKeywordAfterLineBreakReportsErrorAndRecovers") {
+  auto sourceManager = zc::heap<source::SourceManager>();
+  auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
+  basic::LangOptions langOpts;
+  basic::StringPool stringPool;
+
+  auto bufferId =
+      sourceManager->addMemBufferCopy(zc::str("let x = foo\nas(Bar);").asBytes(), "test.zom");
+  Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
+
+  ZC_IF_SOME(root, parser.parse()) {
+    auto& sourceFile = ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::SourceFile>(*root);
+    const auto& statements = sourceFile.getStatements();
+    ZC_EXPECT(statements.size() == 1,
+              "Parser should recover without splitting the invalid cast into another statement");
+    ZC_EXPECT(diagnosticEngine->hasErrors(),
+              "Line-break-separated as-cast should produce a parse error");
+
+    auto& variableStatement =
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
+            statements[0]);
+    const auto& declarations = variableStatement.getDeclarations().getBindings();
+    ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
+
+    ZC_IF_SOME(initializer, declarations[0].getInitializer()) {
+      ZC_EXPECT(initializer.getKind() == ast::SyntaxKind::AsExpression,
+                "Initializer should preserve the cast structure after reporting the error");
+    }
+    else { ZC_EXPECT(false, "Variable declaration should have an initializer"); }
+  }
+  else { ZC_EXPECT(false, "Parser should recover from line-break-separated as-cast"); }
 }
 
 // ================================================================================

--- a/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
+++ b/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
@@ -2025,8 +2025,7 @@ ZC_TEST("ParserTest.ParseCastExpression") {
     ZC_EXPECT(statements.size() == 1, "Should contain one statement");
 
     auto& variableStatement =
-        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
-            statements[0]);
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(statements[0]);
     const auto& declarations = variableStatement.getDeclarations().getBindings();
     ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
 
@@ -2055,8 +2054,7 @@ ZC_TEST("ParserTest.ParseOptionalCastExpression") {
     ZC_EXPECT(statements.size() == 1, "Should contain one statement");
 
     auto& variableStatement =
-        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
-            statements[0]);
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(statements[0]);
     const auto& declarations = variableStatement.getDeclarations().getBindings();
     ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
 
@@ -2085,8 +2083,7 @@ ZC_TEST("ParserTest.ParseForceCastExpression") {
     ZC_EXPECT(statements.size() == 1, "Should contain one statement");
 
     auto& variableStatement =
-        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
-            statements[0]);
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(statements[0]);
     const auto& declarations = variableStatement.getDeclarations().getBindings();
     ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
 
@@ -2118,8 +2115,7 @@ ZC_TEST("ParserTest.ParseAsKeywordAfterLineBreakReportsErrorAndRecovers") {
               "Line-break-separated as-cast should produce a parse error");
 
     auto& variableStatement =
-        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(
-            statements[0]);
+        ::zomlang::compiler::ast::cast<::zomlang::compiler::ast::VariableStatement>(statements[0]);
     const auto& declarations = variableStatement.getDeclarations().getBindings();
     ZC_EXPECT(declarations.size() == 1, "Should contain one variable declaration");
 


### PR DESCRIPTION
## Summary
improve parser type parsing helpers and related parser tests
report an error for line-break-separated \ casts while still preserving cast AST structure
add parser coverage for optional, forced, and line-break-separated \ parsing

## Verification
ctest --preset allTests -R parser-test --output-on-failure