### PR TITLE
fix(parser): complete template and pattern parsing

### DIFF
--- a/docs/spec/ZomLexer.g4
+++ b/docs/spec/ZomLexer.g4
@@ -86,6 +86,7 @@ FUN: 'fun';
 GET: 'get';
 GLOBAL: 'global';
 I8: 'i8';
+I16: 'i16';
 I32: 'i32';
 I64: 'i64';
 IF: 'if';
@@ -126,7 +127,6 @@ STATIC: 'static';
 STR: 'str';
 STRUCT: 'struct';
 SUPER: 'super';
-SWITCH: 'switch';
 SYMBOL: 'symbol';
 THIS: 'this';
 THROW: 'throw';
@@ -246,6 +246,17 @@ SINGLE_ESCAPE_CHARACTER:
 NON_ESCAPE_CHARACTER:
 	~['"\\bfnrtvxu0-9LF\u000A\u000D\u2028\u2029];
 // Any source character not part of an escape sequence
+
+// ================================================================================ TEMPLATE LITERALS
+TEMPLATE_ESCAPE_SEQUENCE: BACKSLASH .;
+NO_SUBSTITUTION_TEMPLATE_LITERAL:
+	'`' (~[`\\] | TEMPLATE_ESCAPE_SEQUENCE)* '`';
+TEMPLATE_HEAD:
+	'`' (~[`\\$] | TEMPLATE_ESCAPE_SEQUENCE | DOLLAR ~[{])* DOLLAR LBRACE;
+TEMPLATE_MIDDLE:
+	RBRACE (~[`\\$] | TEMPLATE_ESCAPE_SEQUENCE | DOLLAR ~[{])* DOLLAR LBRACE;
+TEMPLATE_TAIL:
+	RBRACE (~[`\\] | TEMPLATE_ESCAPE_SEQUENCE)* '`';
 
 // ================================================================================ CHARACTER LITERALS
 CHAR_LITERAL:

--- a/docs/spec/ZomParser.g4
+++ b/docs/spec/ZomParser.g4
@@ -115,6 +115,7 @@ literal:
 	| booleanLiteral
 	| numericLiteral
 	| stringLiteral
+	| templateLiteral
 	| characterLiteral;
 
 //// =============================================================================== NIL LITERALS
@@ -213,6 +214,13 @@ lineContinuation: BACKSLASH lineTerminatorSequence;
 
 // ================================================================================ TEMPLATE LITERALS
 
+templateLiteral:
+	NO_SUBSTITUTION_TEMPLATE_LITERAL
+	| TEMPLATE_HEAD templateSpan+;
+
+templateSpan:
+	expression (TEMPLATE_MIDDLE | TEMPLATE_TAIL);
+
 codePoint:
 	hexDigits {
     String hexText = _input.getText(_localctx.hexDigits());
@@ -242,17 +250,8 @@ primaryExpression:
 	| literal
 	| arrayLiteral
 	| objectLiteral
-	| coverParenthesizedExpressionAndArrowParameterList;
-
-// Cover Parenthesized Expression and Arrow Parameter List
-coverParenthesizedExpressionAndArrowParameterList:
-	LPAREN expression RPAREN
-	| LPAREN expression COMMA RPAREN
-	| LPAREN RPAREN
-	| LPAREN ELLIPSIS bindingIdentifier RPAREN
-	| LPAREN ELLIPSIS bindingPattern RPAREN
-	| LPAREN expression COMMA ELLIPSIS bindingIdentifier RPAREN
-	| LPAREN expression COMMA ELLIPSIS bindingPattern RPAREN;
+	| functionExpression
+	| LPAREN expression RPAREN;
 
 // Object LiteralExpression
 objectLiteral:
@@ -699,7 +698,7 @@ typeQueryExpression: identifier ( PERIOD identifier)*;
 typeArguments: LT typeArgumentList GT;
 typeArgumentList: type (COMMA type)*;
 propertySignature: propertyName QUESTION? typeAnnotation;
-propertyName: identifier | stringLiteral | numericLiteral;
+propertyName: identifier;
 typeParameters: LT typeParameterList GT;
 typeParameterList: typeParameter (COMMA typeParameter)*;
 typeParameter: identifier constraint?;

--- a/docs/spec/chapters/02-lexical-structure.md
+++ b/docs/spec/chapters/02-lexical-structure.md
@@ -123,16 +123,16 @@ declare
 if          else        match       when        default     case
 for         while       do          break       continue
 return      throw       try         catch       finally
-switch      debugger
+debugger
 ```
 
 ### Type Keywords
 
 ```
-i8          i32         i64         u8          u16
-u32         u64         f32         f64         bool
-str         null        unit        any         never
-object      symbol      bigint      undefined   void
+i8          i16         i32         i64         u8
+u16         u32         u64         f32         f64
+bool        str         null        unit        any
+never       object      symbol      bigint      undefined
 ```
 
 ### Modifier Keywords
@@ -371,5 +371,5 @@ Character literals represent single Unicode characters:
 !!          Force unwrap
 ?:          Error default
 ->          Arrow (function return type)
-=>          Rocket (lambda, match arms)
+=>          Rocket (match arms)
 ```

--- a/docs/spec/chapters/03-types.md
+++ b/docs/spec/chapters/03-types.md
@@ -196,9 +196,9 @@ type Mapper<T, U> = (T -> U, T[]) -> U[];
 type SafeParser = (str) -> i32 raises ParseError;
 
 // Examples
-let add: BinaryOp = (a, b) => a + b;
-let getString: Supplier<str> = () => "hello";
-let print: Consumer<str> = (s) => console.log(s);
+let add: BinaryOp = fun (a: i32, b: i32) -> i32 { return a + b; };
+let getString: Supplier<str> = fun () -> str { return "hello"; };
+let print: Consumer<str> = fun (s: str) -> unit { console.log(s); };
 ```
 
 ### Object Types
@@ -256,7 +256,7 @@ fun greet(name: str): str {
 }
 
 // Complex type annotations
-let callback: (str) -> bool = (s) => s.length > 0;
+let callback: (str) -> bool = fun (s: str) -> bool { return s.length > 0; };
 let data: { id: i32, values: f64[] } = {
     id: 1,
     values: [1.0, 2.0, 3.0]

--- a/docs/spec/chapters/04-expressions.md
+++ b/docs/spec/chapters/04-expressions.md
@@ -10,7 +10,7 @@ Expressions are constructs that evaluate to values. Zom provides a rich set of e
 4. **Binary Expressions**: Arithmetic, logical, comparison operators
 5. **Conditional Expressions**: Ternary operator
 6. **Assignment Expressions**: Value assignment
-7. **Closure Expressions**: Anonymous functions
+7. **Function Expressions**: Anonymous functions
 
 ## Primary Expressions
 
@@ -89,11 +89,10 @@ let person = {
     isActive: true
 };
 
-// Computed property names
-let key = "dynamicKey";
+// Object literal property names must be identifiers.
 let obj = {
-    [key]: "value",
-    ["computed" + "Key"]: 42
+    dynamicKey: "value",
+    computedKey: 42
 };
 
 // Property shorthand
@@ -348,35 +347,29 @@ result ||= defaultValue; // Logical OR assignment
 result ??= fallbackValue; // Null coalescing assignment
 ```
 
-## Closure Expressions
+## Function Expressions
 
-Closure expressions create anonymous functions:
+Function expressions create anonymous functions:
 
 ```zom
-// Basic closure
-let add = (a: i32, b: i32) => a + b;
+// Basic function expression
+let add = fun (a: i32, b: i32) -> i32 { return a + b; };
 
-// Closure with block body
-let complexOperation = (x: i32) => {
+// Function expression with block body
+let complexOperation = fun (x: i32) -> i32 {
     let doubled = x * 2;
     let squared = doubled * doubled;
     return squared;
 };
 
-// Closure with inferred types
+// Function expression as an argument
 let numbers = [1, 2, 3, 4, 5];
-let doubled = numbers.map(x => x * 2);
-let filtered = numbers.filter(x => x > 2);
+let doubled = numbers.map(fun (x: i32) -> i32 { return x * 2; });
+let filtered = numbers.filter(fun (x: i32) -> bool { return x > 2; });
 
-// Closure capturing variables
+// Function expression capturing variables
 let multiplier = 3;
-let multiply = (x: i32) => x * multiplier;
-
-// Async closure
-let asyncOperation = async (url: str) => {
-    let response = await fetch(url);
-    return await response.text();
-};
+let multiply = fun (x: i32) -> i32 { return x * multiplier; };
 ```
 
 ## Operator Precedence

--- a/docs/spec/chapters/12-generics.md
+++ b/docs/spec/chapters/12-generics.md
@@ -48,7 +48,7 @@ class Box<T> {
 
 // Usage
 let intBox = Box(42);
-let stringBox = intBox.map(x => x.toString());
+let stringBox = intBox.map(fun (x: i32) -> str { return x.toString(); });
 ```
 
 ### Generic Interfaces

--- a/docs/spec/chapters/15-concurrency.md
+++ b/docs/spec/chapters/15-concurrency.md
@@ -27,14 +27,14 @@ async fun processUser(userId: i64) {
 ```zom
 // Parallel execution
 async fun fetchMultipleUsers(userIds: i64[]) -> User[] {
-    let tasks = userIds.map(id => fetchUserData(id));
+    let tasks = userIds.map(fun (id: UserId) -> Task<User> { return fetchUserData(id); });
     return await Promise.all(tasks);
 }
 
 // Racing operations
 async fun fetchWithTimeout(url: str, timeoutMs: i32) -> str {
     let fetchTask = httpClient.get(url);
-    let timeoutTask = Timer.delay(timeoutMs).then(() => {
+    let timeoutTask = Timer.delay(timeoutMs).then(fun () -> unit {
         throw TimeoutError("Request timed out");
     });
 

--- a/docs/spec/chapters/17-grammar-reference.md
+++ b/docs/spec/chapters/17-grammar-reference.md
@@ -50,6 +50,9 @@ StringLiteral ::= '"' DoubleStringCharacter* '"' | "'" SingleStringCharacter* "'
 DoubleStringCharacter ::= ~["\\\r\n\u2028\u2029] | LineTerminator | '\\' EscapeSequence | LineContinuation
 SingleStringCharacter ::= ~['\\\r\n\u2028\u2029] | LineTerminator | '\\' EscapeSequence | LineContinuation
 
+TemplateLiteral ::= NoSubstitutionTemplateLiteral | TemplateHead TemplateSpan+
+TemplateSpan ::= Expression (TemplateMiddle | TemplateTail)
+
 EscapeSequence ::= CharacterEscapeSequence | '0' | HexEscapeSequence | UnicodeEscapeSequence
 CharacterEscapeSequence ::= '\\' ["\\bfnrtv]
 HexEscapeSequence ::= 'x' HEX_DIGIT HEX_DIGIT
@@ -306,7 +309,7 @@ PropertyDefinitionList ::= PropertyDefinition (',' PropertyDefinition)*
 PropertyDefinition ::= Identifier
                     | PropertyName ':' Expression
                     | '...' Expression
-PropertyName ::= Identifier | StringLiteral | NumericLiteral
+PropertyName ::= Identifier
 
 FunctionExpression ::= 'fun' CallSignature BlockStatement
 

--- a/products/zomlang/compiler/ast/factory.cc
+++ b/products/zomlang/compiler/ast/factory.cc
@@ -580,10 +580,13 @@ zc::Own<ContinueStatement> createContinueStatement(zc::Maybe<zc::Own<Identifier>
 //   return zc::heap<PrimaryPattern>();
 // }
 
-zc::Own<WildcardPattern> createWildcardPattern() { return zc::heap<WildcardPattern>(); }
+zc::Own<WildcardPattern> createWildcardPattern(zc::Maybe<zc::Own<TypeNode>> typeAnnotation) {
+  return zc::heap<WildcardPattern>(zc::mv(typeAnnotation));
+}
 
-zc::Own<IdentifierPattern> createIdentifierPattern(zc::Own<Identifier> identifier) {
-  return zc::heap<IdentifierPattern>(zc::mv(identifier));
+zc::Own<IdentifierPattern> createIdentifierPattern(zc::Own<Identifier> identifier,
+                                                   zc::Maybe<zc::Own<TypeNode>> typeAnnotation) {
+  return zc::heap<IdentifierPattern>(zc::mv(identifier), zc::mv(typeAnnotation));
 }
 
 zc::Own<TuplePattern> createTuplePattern(zc::Vector<zc::Own<Pattern>>&& elements) {
@@ -606,14 +609,12 @@ zc::Own<ExpressionPattern> createExpressionPattern(zc::Own<Expression> expressio
   return zc::heap<ExpressionPattern>(zc::mv(expression));
 }
 
-zc::Own<EnumPattern> createEnumPattern(zc::Own<TypeReferenceNode> typeReference,
+zc::Own<EnumPattern> createEnumPattern(zc::Maybe<zc::Own<TypeReferenceNode>> typeReference,
                                        zc::Own<Identifier> propertyName,
                                        zc::Maybe<zc::Own<TuplePattern>> tuplePattern) {
-  // TODO: Fix type conversion from TypeReferenceNode to Type
-  // For now, cast TypeReferenceNode to Type since TypeReferenceNode inherits from Type
-  zc::Maybe<zc::Own<TypeNode>> typeRef = zc::mv(typeReference);
+  zc::Maybe<zc::Own<TypeNode>> typeRef = zc::none;
+  ZC_IF_SOME(typeReferenceNode, zc::mv(typeReference)) { typeRef = zc::mv(typeReferenceNode); }
 
-  // TODO: Handle optional TuplePattern - for now create empty one if none provided
   zc::Own<TuplePattern> tuple;
   ZC_IF_SOME(tp, tuplePattern) { tuple = zc::mv(tp); }
   else { tuple = zc::heap<TuplePattern>(zc::Vector<zc::Own<Pattern>>()); }

--- a/products/zomlang/compiler/ast/factory.h
+++ b/products/zomlang/compiler/ast/factory.h
@@ -439,9 +439,11 @@ zc::Own<NamedTupleElement> createNamedTupleElement(zc::Own<Identifier> name,
 /// Pattern factory functions
 // zc::Own<PrimaryPattern> createPrimaryPattern(zc::Own<Expression> expression);
 
-zc::Own<WildcardPattern> createWildcardPattern();
+zc::Own<WildcardPattern> createWildcardPattern(
+    zc::Maybe<zc::Own<TypeNode>> typeAnnotation = zc::none);
 
-zc::Own<IdentifierPattern> createIdentifierPattern(zc::Own<Identifier> identifier);
+zc::Own<IdentifierPattern> createIdentifierPattern(
+    zc::Own<Identifier> identifier, zc::Maybe<zc::Own<TypeNode>> typeAnnotation = zc::none);
 
 zc::Own<TuplePattern> createTuplePattern(zc::Vector<zc::Own<Pattern>>&& elements);
 
@@ -456,7 +458,7 @@ zc::Own<IsPattern> createIsPattern(zc::Own<TypeNode> type);
 
 zc::Own<ExpressionPattern> createExpressionPattern(zc::Own<Expression> expression);
 
-zc::Own<EnumPattern> createEnumPattern(zc::Own<TypeReferenceNode> typeReference,
+zc::Own<EnumPattern> createEnumPattern(zc::Maybe<zc::Own<TypeReferenceNode>> typeReference,
                                        zc::Own<Identifier> propertyName,
                                        zc::Maybe<zc::Own<TuplePattern>> tuplePattern = zc::none);
 

--- a/products/zomlang/compiler/ast/kinds.h
+++ b/products/zomlang/compiler/ast/kinds.h
@@ -104,7 +104,6 @@ enum class SyntaxKind {
   SetKeyword,          // set
   StaticKeyword,       // static
   SuperKeyword,        // super
-  SwitchKeyword,       // switch
   SymbolKeyword,       // symbol
   ThisKeyword,         // this
   ThrowKeyword,        // throw

--- a/products/zomlang/compiler/lexer/lexer.cc
+++ b/products/zomlang/compiler/lexer/lexer.cc
@@ -142,6 +142,7 @@ struct Lexer::Impl {
   void lex();
 
   ast::SyntaxKind reScanGreaterToken();
+  ast::SyntaxKind reScanTemplateToken();
 
   /// \brief Lex an identifier.
   /// \param prefixLength The length of the prefix (e.g., '$' for a global identifier).
@@ -796,6 +797,18 @@ ast::SyntaxKind Lexer::Impl::reScanGreaterToken() {
   return state.token.getKind();
 }
 
+ast::SyntaxKind Lexer::Impl::reScanTemplateToken() {
+  if (!state.token.is(ast::SyntaxKind::RightBrace)) { return state.token.getKind(); }
+
+  state.curPtr = state.tokenStartPtr;
+  state.tokenFlags = TokenFlags::None;
+
+  zc::StringPtr value;
+  const ast::SyntaxKind kind = lexTemplateAndRetTokenValue(false, value);
+  formToken(kind, value);
+  return state.token.getKind();
+}
+
 zc::Maybe<zc::StringPtr> Lexer::Impl::lexIdentifier(int32_t prefixLength) {
   const zc::byte* start = state.curPtr;
   state.curPtr += prefixLength;
@@ -1404,6 +1417,8 @@ void Lexer::lex(Token& outToken) {
 }
 
 ast::SyntaxKind Lexer::reScanGreaterToken() { return impl->reScanGreaterToken(); }
+
+ast::SyntaxKind Lexer::reScanTemplateToken() { return impl->reScanTemplateToken(); }
 
 void Lexer::restoreState(LexerState s, bool enableDiagnostics) {
   impl->state.curPtr = s.curPtr;

--- a/products/zomlang/compiler/lexer/lexer.h
+++ b/products/zomlang/compiler/lexer/lexer.h
@@ -88,6 +88,7 @@ public:
   void lex(Token& outToken);
 
   ZC_NODISCARD ast::SyntaxKind reScanGreaterToken();
+  ZC_NODISCARD ast::SyntaxKind reScanTemplateToken();
 
   /// \brief Restore the lexer state.
   /// \param s The state to restore.

--- a/products/zomlang/compiler/lexer/token.cc
+++ b/products/zomlang/compiler/lexer/token.cc
@@ -224,8 +224,6 @@ constexpr zc::StringPtr getStaticTextForTokenKindImpl(ast::SyntaxKind kind) {
       return "with"_zc;
     case ast::SyntaxKind::WhenKeyword:
       return "when"_zc;
-    case ast::SyntaxKind::SwitchKeyword:
-      return "switch"_zc;
     case ast::SyntaxKind::CaseKeyword:
       return "case"_zc;
     case ast::SyntaxKind::MatchKeyword:
@@ -248,6 +246,8 @@ constexpr zc::StringPtr getStaticTextForTokenKindImpl(ast::SyntaxKind kind) {
       return "bool"_zc;
     case ast::SyntaxKind::I8Keyword:
       return "i8"_zc;
+    case ast::SyntaxKind::I16Keyword:
+      return "i16"_zc;
     case ast::SyntaxKind::I32Keyword:
       return "i32"_zc;
     case ast::SyntaxKind::I64Keyword:

--- a/products/zomlang/compiler/lexer/utils.cc
+++ b/products/zomlang/compiler/lexer/utils.cc
@@ -229,7 +229,6 @@ ast::SyntaxKind getKeywordKind(zc::ArrayPtr<const zc::byte> text) {
   if (text == "set"_zcb) return ast::SyntaxKind::SetKeyword;
   if (text == "static"_zcb) return ast::SyntaxKind::StaticKeyword;
   if (text == "super"_zcb) return ast::SyntaxKind::SuperKeyword;
-  if (text == "switch"_zcb) return ast::SyntaxKind::SwitchKeyword;
   if (text == "symbol"_zcb) return ast::SyntaxKind::SymbolKeyword;
   if (text == "this"_zcb) return ast::SyntaxKind::ThisKeyword;
   if (text == "throw"_zcb) return ast::SyntaxKind::ThrowKeyword;
@@ -245,6 +244,7 @@ ast::SyntaxKind getKeywordKind(zc::ArrayPtr<const zc::byte> text) {
 
   if (text == "bool"_zcb) return ast::SyntaxKind::BoolKeyword;
   if (text == "i8"_zcb) return ast::SyntaxKind::I8Keyword;
+  if (text == "i16"_zcb) return ast::SyntaxKind::I16Keyword;
   if (text == "i32"_zcb) return ast::SyntaxKind::I32Keyword;
   if (text == "i64"_zcb) return ast::SyntaxKind::I64Keyword;
   if (text == "u8"_zcb) return ast::SyntaxKind::U8Keyword;

--- a/products/zomlang/compiler/parser/parser.cc
+++ b/products/zomlang/compiler/parser/parser.cc
@@ -857,7 +857,6 @@ bool Parser::isStartOfStatement() {
     case ast::SyntaxKind::BreakKeyword:      // break statement
     case ast::SyntaxKind::ReturnKeyword:     // return statement
     case ast::SyntaxKind::WithKeyword:       // with statement
-    case ast::SyntaxKind::SwitchKeyword:     // switch statement
     case ast::SyntaxKind::MatchKeyword:      // match statement
     case ast::SyntaxKind::ThrowKeyword:      // throw statement
     case ast::SyntaxKind::TryKeyword:        // try statement
@@ -987,6 +986,12 @@ ZC_ALWAYS_INLINE(ast::SyntaxKind Parser::currentKind() const) { return currentTo
 
 ast::SyntaxKind Parser::reScanGreaterToken() {
   ast::SyntaxKind kind = impl->lexer.reScanGreaterToken();
+  impl->token = impl->lexer.getCurrentState().token;
+  return kind;
+}
+
+ast::SyntaxKind Parser::reScanTemplateToken() {
+  ast::SyntaxKind kind = impl->lexer.reScanTemplateToken();
   impl->token = impl->lexer.getCurrentState().token;
   return kind;
 }
@@ -1592,6 +1597,17 @@ zc::Own<ast::Identifier> Parser::createIdentifier(bool isIdentifier) {
 zc::Own<ast::Identifier> Parser::parsePropertyName() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parsePropertyName");
 
+  if (expectToken(ast::SyntaxKind::LeftBracket)) {
+    const source::SourceLoc loc = currentLoc();
+    parseErrorAtCurrentToken<diagnostics::DiagID::ExceptedIdentifier>(currentToken().getValue());
+    nextToken();
+    while (!expectNToken(ast::SyntaxKind::RightBracket, ast::SyntaxKind::EndOfFile)) {
+      nextToken();
+    }
+    parseOptional(ast::SyntaxKind::RightBracket);
+    return finishNode(ast::factory::createMissingIdentifier(), loc);
+  }
+
   if (expectNToken(ast::SyntaxKind::StringLiteral, ast::SyntaxKind::IntegerLiteral,
                    ast::SyntaxKind::FloatLiteral, ast::SyntaxKind::BigIntLiteral)) {
     source::SourceLoc loc = currentLoc();
@@ -1778,13 +1794,13 @@ zc::Maybe<zc::Own<ast::ExpressionStatement>> Parser::parseExpressionStatement() 
 namespace {
 
 static const zc::StringPtr kViableKeywordSuggestions[] = {
-    "let"_zc,       "const"_zc,      "fun"_zc,      "class"_zc,  "interface"_zc, "module"_zc,
-    "namespace"_zc, "type"_zc,       "import"_zc,   "export"_zc, "return"_zc,    "if"_zc,
-    "else"_zc,      "for"_zc,        "while"_zc,    "switch"_zc, "new"_zc,       "try"_zc,
-    "throw"_zc,     "break"_zc,      "continue"_zc, "async"_zc,  "await"_zc,     "yield"_zc,
-    "extends"_zc,   "implements"_zc, "this"_zc,     "super"_zc,  "package"_zc,   "void"_zc,
-    "private"_zc,   "protected"_zc,  "public"_zc,   "static"_zc, "readonly"_zc,  "abstract"_zc,
-    "override"_zc,  "declare"_zc,    "get"_zc,      "set"_zc,    "enum"_zc};
+    "let"_zc,        "const"_zc,    "fun"_zc,      "class"_zc,    "interface"_zc, "module"_zc,
+    "namespace"_zc,  "type"_zc,     "import"_zc,   "export"_zc,   "return"_zc,    "if"_zc,
+    "else"_zc,       "for"_zc,      "while"_zc,    "new"_zc,      "try"_zc,       "throw"_zc,
+    "break"_zc,      "continue"_zc, "async"_zc,    "await"_zc,    "yield"_zc,     "extends"_zc,
+    "implements"_zc, "this"_zc,     "super"_zc,    "package"_zc,  "private"_zc,   "protected"_zc,
+    "public"_zc,     "static"_zc,   "readonly"_zc, "abstract"_zc, "override"_zc,  "declare"_zc,
+    "get"_zc,        "set"_zc,      "enum"_zc};
 
 size_t levenshteinDistance(zc::StringPtr s1, zc::StringPtr s2) {
   const size_t n = s1.size();
@@ -2572,7 +2588,6 @@ zc::Own<ast::Expression> Parser::parseUnaryExpressionOrHigher() {
   //
   // prefixUnaryExpression:
   //   postfixUnaryExpression
-  //   | VOID prefixUnaryExpression
   //   | TYPEOF prefixUnaryExpression
   //   | PLUS prefixUnaryExpression
   //   | MINUS prefixUnaryExpression
@@ -2649,27 +2664,6 @@ zc::Own<ast::UnaryExpression> Parser::parsePrefixUnaryExpression() {
   // Parse the operand (recursive call to parseSimpleUnaryExpression)
   return finishNode(
       ast::factory::createPrefixUnaryExpression(zc::mv(op), parseSimpleUnaryExpression()), loc);
-}
-
-// Void expression parsing
-zc::Maybe<zc::Own<ast::VoidExpression>> Parser::parseVoidExpression() {
-  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseVoidExpression");
-
-  // voidExpression:
-  //   VOID unaryExpression;
-  //
-  // Parse void operator expression
-
-  const source::SourceLoc loc = currentLoc();
-
-  nextToken();
-
-  // Parse the operand
-  auto operand = parseSimpleUnaryExpression();
-
-  // Create void expression
-  auto voidExpr = ast::factory::createVoidExpression(zc::mv(operand));
-  return finishNode(zc::mv(voidExpr), loc);
 }
 
 // TypeOf expression parsing
@@ -2873,10 +2867,13 @@ zc::Own<ast::PrimaryExpression> Parser::parsePrimaryExpression() {
     case ast::SyntaxKind::FloatLiteral:
     case ast::SyntaxKind::BigIntLiteral:
     case ast::SyntaxKind::StringLiteral:
+    case ast::SyntaxKind::NoSubstitutionTemplateLiteral:
     case ast::SyntaxKind::TrueKeyword:
     case ast::SyntaxKind::FalseKeyword:
     case ast::SyntaxKind::NullKeyword:
       return parseLiteralExpression();
+    case ast::SyntaxKind::TemplateHead:
+      return parseTemplateLiteralExpression();
     case ast::SyntaxKind::LeftParen:
       return parseParenthesizedExpression();
     case ast::SyntaxKind::LeftBracket:
@@ -2956,6 +2953,48 @@ zc::Own<ast::LiteralExpression> Parser::parseLiteralExpression() {
       ZC_UNREACHABLE;
     }
   }
+}
+
+zc::Own<ast::TemplateLiteralExpression> Parser::parseTemplateLiteralExpression() {
+  trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parseTemplateLiteralExpression");
+
+  const source::SourceLoc loc = currentLoc();
+  const lexer::Token headToken = currentToken();
+  parseExpected(ast::SyntaxKind::TemplateHead);
+
+  auto head = finishNode(ast::factory::createStringLiteral(headToken.getValue()),
+                         headToken.getRange().getStart(), headToken.getRange().getEnd());
+
+  zc::Vector<zc::Own<ast::TemplateSpan>> spans;
+  while (true) {
+    const source::SourceLoc spanLoc = currentLoc();
+    auto expression = parseExpression();
+
+    if (!expectToken(ast::SyntaxKind::RightBrace)) {
+      parseExpected(ast::SyntaxKind::RightBrace);
+      break;
+    }
+
+    const ast::SyntaxKind literalKind = reScanTemplateToken();
+    if (literalKind != ast::SyntaxKind::TemplateMiddle &&
+        literalKind != ast::SyntaxKind::TemplateTail) {
+      parseExpected(ast::SyntaxKind::TemplateTail);
+      break;
+    }
+
+    const lexer::Token literalToken = currentToken();
+    auto literal = finishNode(ast::factory::createStringLiteral(literalToken.getValue()),
+                              literalToken.getRange().getStart(), literalToken.getRange().getEnd());
+
+    spans.add(finishNode(ast::factory::createTemplateSpan(zc::mv(expression), zc::mv(literal)),
+                         spanLoc, literalToken.getRange().getEnd()));
+
+    nextToken();
+    if (literalKind == ast::SyntaxKind::TemplateTail) { break; }
+  }
+
+  return finishNode(ast::factory::createTemplateLiteralExpression(zc::mv(head), zc::mv(spans)),
+                    loc);
 }
 
 zc::Own<ast::Expression> Parser::parseSpreadElement() {
@@ -3477,8 +3516,6 @@ zc::Maybe<zc::Own<ast::TupleTypeNode>> Parser::parseTupleType() {
 
   if (!consumeExpectedToken(ast::SyntaxKind::LeftParen)) { return zc::none; }
 
-  // TODO: Implement TupleElement class
-  // zc::Vector<zc::Own<ast::TupleElement>> elements;
   zc::Vector<zc::Own<ast::TypeNode>> elements;
 
   if (!expectToken(ast::SyntaxKind::RightParen)) {
@@ -3548,14 +3585,15 @@ zc::Maybe<zc::Own<ast::PredefinedTypeNode>> Parser::parsePredefinedType() {
   trace::ScopeTracer scopeTracer(trace::TraceCategory::kParser, "parsePredefinedType");
 
   // Parse predefined type according to the grammar rule:
-  // predefinedType: I8 | I32 | I64 | U8 | U16 | U32 | U64 | F32 | F64 | STR | BOOL | NIL | UNIT
-  // These are the built-in primitive types in the ZOM language
+  // predefinedType: I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | F32 | F64 | STR | BOOL | NIL |
+  // UNIT These are the built-in primitive types in the ZOM language
 
   const lexer::Token& token = currentToken();
   const source::SourceLoc loc = token.getLocation();
 
   switch (token.getKind()) {
     case ast::SyntaxKind::I8Keyword:
+    case ast::SyntaxKind::I16Keyword:
     case ast::SyntaxKind::I32Keyword:
     case ast::SyntaxKind::I64Keyword:
     case ast::SyntaxKind::U8Keyword:
@@ -3584,8 +3622,65 @@ zc::Maybe<zc::Own<ast::Pattern>> Parser::parsePattern() {
   switch (currentKind()) {
     case ast::SyntaxKind::Underscore:
       return parseWildcardPattern();
-    case ast::SyntaxKind::Identifier:
-      return parseIdentifierPattern();
+    case ast::SyntaxKind::Identifier: {
+      const lexer::Token firstToken = currentToken();
+      if (firstToken.getValue() == "_"_zc &&
+          (isLookAhead(1, ast::SyntaxKind::Colon) ||
+           isLookAhead(1, ast::SyntaxKind::EqualsGreaterThan) ||
+           isLookAhead(1, ast::SyntaxKind::IfKeyword) || isLookAhead(1, ast::SyntaxKind::Comma) ||
+           isLookAhead(1, ast::SyntaxKind::Semicolon) ||
+           isLookAhead(1, ast::SyntaxKind::RightParen) ||
+           isLookAhead(1, ast::SyntaxKind::RightBracket) ||
+           isLookAhead(1, ast::SyntaxKind::RightBrace) ||
+           isLookAhead(1, ast::SyntaxKind::EndOfFile))) {
+        return parseWildcardPattern();
+      }
+
+      if (isLookAhead(1, ast::SyntaxKind::LeftParen)) {
+        const source::SourceLoc loc = currentLoc();
+        auto propertyName = parseIdentifier();
+        ZC_IF_SOME(pattern, parseTuplePattern()) {
+          auto tuplePattern = ast::cast<ast::TuplePattern>(zc::mv(pattern));
+          return finishNode(
+              ast::factory::createEnumPattern(zc::none, zc::mv(propertyName), zc::mv(tuplePattern)),
+              loc);
+        }
+      }
+
+      if (isLookAhead(1, ast::SyntaxKind::Period)) {
+        const source::SourceLoc loc = currentLoc();
+        auto typeReference =
+            finishNode(ast::factory::createTypeReference(
+                           ast::factory::createIdentifier(firstToken.getValue()),
+                           zc::Maybe<zc::Vector<zc::Own<ast::TypeNode>>>{zc::none}),
+                       firstToken.getRange().getStart(), firstToken.getRange().getEnd());
+        nextToken();
+        parseExpected(ast::SyntaxKind::Period);
+        auto propertyName = parseIdentifier();
+        zc::Maybe<zc::Own<ast::TuplePattern>> tuplePattern = zc::none;
+        if (expectToken(ast::SyntaxKind::LeftParen)) {
+          ZC_IF_SOME(pattern, parseTuplePattern()) {
+            tuplePattern = ast::cast<ast::TuplePattern>(zc::mv(pattern));
+          }
+        }
+        return finishNode(ast::factory::createEnumPattern(
+                              zc::mv(typeReference), zc::mv(propertyName), zc::mv(tuplePattern)),
+                          loc);
+      }
+
+      if (isLookAhead(1, ast::SyntaxKind::Colon) ||
+          isLookAhead(1, ast::SyntaxKind::EqualsGreaterThan) ||
+          isLookAhead(1, ast::SyntaxKind::IfKeyword) || isLookAhead(1, ast::SyntaxKind::Comma) ||
+          isLookAhead(1, ast::SyntaxKind::Semicolon) ||
+          isLookAhead(1, ast::SyntaxKind::RightParen) ||
+          isLookAhead(1, ast::SyntaxKind::RightBracket) ||
+          isLookAhead(1, ast::SyntaxKind::RightBrace) ||
+          isLookAhead(1, ast::SyntaxKind::EndOfFile)) {
+        return parseIdentifierPattern();
+      }
+
+      return ast::factory::createExpressionPattern(parseExpression());
+    }
     case ast::SyntaxKind::LeftParen:
       return parseTuplePattern();
     case ast::SyntaxKind::LeftBrace:
@@ -3606,19 +3701,15 @@ zc::Maybe<zc::Own<ast::Pattern>> Parser::parseWildcardPattern() {
   zc::Maybe<zc::Own<ast::TypeNode>> type;
   if (consumeExpectedToken(ast::SyntaxKind::Colon)) { type = parseType(); }
 
-  // TODO: Handle type annotation for wildcard patterns
-  static_cast<void>(type);
-  return finishNode(ast::factory::createWildcardPattern(), loc);
+  return finishNode(ast::factory::createWildcardPattern(zc::mv(type)), loc);
 }
 
 zc::Maybe<zc::Own<ast::Pattern>> Parser::parseIdentifierPattern() {
+  const source::SourceLoc loc = currentLoc();
   auto id = parseIdentifier();
   zc::Maybe<zc::Own<ast::TypeNode>> type;
-  if (consumeExpectedToken(ast::SyntaxKind::Colon)) {
-    type = parseType();
-    static_cast<void>(type);
-  }
-  return ast::factory::createIdentifierPattern(zc::mv(id));
+  if (consumeExpectedToken(ast::SyntaxKind::Colon)) { type = parseType(); }
+  return finishNode(ast::factory::createIdentifierPattern(zc::mv(id), zc::mv(type)), loc);
 }
 
 zc::Maybe<zc::Own<ast::Pattern>> Parser::parseTuplePattern() {

--- a/products/zomlang/compiler/parser/parser.h
+++ b/products/zomlang/compiler/parser/parser.h
@@ -81,7 +81,6 @@ class CallExpression;
 class MemberExpression;
 class UpdateExpression;
 class CastExpression;
-class VoidExpression;
 class TypeOfExpression;
 class AwaitExpression;
 class LeftHandSideExpression;
@@ -209,6 +208,7 @@ private:
   ZC_NODISCARD source::SourceLoc getTokenStartLoc() const;
   ZC_NODISCARD bool hasPrecedingLineBreak() const;
   ast::SyntaxKind reScanGreaterToken();
+  ast::SyntaxKind reScanTemplateToken();
 
   ZC_ALWAYS_INLINE(bool expectToken(ast::SyntaxKind kind));
   // Returns true if the current token matches any of the provided kinds.
@@ -463,7 +463,6 @@ private:
   zc::Maybe<zc::Own<ast::Expression>> parseUnaryExpression();
   zc::Own<ast::UnaryExpression> parseSimpleUnaryExpression();
   zc::Own<ast::UnaryExpression> parsePrefixUnaryExpression();
-  zc::Maybe<zc::Own<ast::VoidExpression>> parseVoidExpression();
   zc::Own<ast::TypeOfExpression> parseTypeOfExpression();
   zc::Own<ast::UpdateExpression> parseUpdateExpression();
 
@@ -496,6 +495,7 @@ private:
 
   // Literals
   zc::Own<ast::LiteralExpression> parseLiteralExpression();
+  zc::Own<ast::TemplateLiteralExpression> parseTemplateLiteralExpression();
   zc::Own<ast::Expression> parseSpreadElement();
   zc::Maybe<zc::Own<ast::Expression>> parseArrayLiteralElement();
   zc::Own<ast::ArrayLiteralExpression> parseArrayLiteralExpression();

--- a/products/zomlang/tests/language/errors/interface-invalid-method-type.zom
+++ b/products/zomlang/tests/language/errors/interface-invalid-method-type.zom
@@ -1,32 +1,37 @@
 // RUN: ! %zomc compile --dump-ast %s 2>&1 | %FileCheck %s
 
-interface Drawable { draw(): void; }
+interface Drawable { draw(): unit; }
 
 
 // CHECK: Error [ZOM2053]: Property or signature expected
 // CHECK:   --> {{.*interface-invalid-method-type.zom}}:3:22
 // CHECK:   |
-// CHECK: 3 | interface Drawable { draw(): void; }
+// CHECK: 3 | interface Drawable { draw(): unit; }
 // CHECK:   |                      ^~~~
 // CHECK: Error [ZOM2025]: Expected '}'
 // CHECK:   --> {{.*interface-invalid-method-type.zom}}:3:22
 // CHECK:   |
-// CHECK: 3 | interface Drawable { draw(): void; }
+// CHECK: 3 | interface Drawable { draw(): unit; }
 // CHECK:   |                      ^~~~
 // CHECK: Error [ZOM2025]: Expected ';'
 // CHECK:   --> {{.*interface-invalid-method-type.zom}}:3:28
 // CHECK:   |
-// CHECK: 3 | interface Drawable { draw(): void; }
+// CHECK: 3 | interface Drawable { draw(): unit; }
 // CHECK:   |                            ^
 // CHECK: Error [ZOM2049]: Declaration or statement expected
 // CHECK:   --> {{.*interface-invalid-method-type.zom}}:3:28
 // CHECK:   |
-// CHECK: 3 | interface Drawable { draw(): void; }
+// CHECK: 3 | interface Drawable { draw(): unit; }
 // CHECK:   |                            ^
+// CHECK: Error [ZOM2049]: Declaration or statement expected
+// CHECK:   --> {{.*interface-invalid-method-type.zom}}:3:30
+// CHECK:   |
+// CHECK: 3 | interface Drawable { draw(): unit; }
+// CHECK:   |                              ^~~~
 // CHECK: Error [ZOM2049]: Declaration or statement expected
 // CHECK:   --> {{.*interface-invalid-method-type.zom}}:3:36
 // CHECK:   |
-// CHECK: 3 | interface Drawable { draw(): void; }
+// CHECK: 3 | interface Drawable { draw(): unit; }
 // CHECK:   |                                    ^
 // CHECK: {{.*zomc}} compile: Compilation failed due to parsing errors.
 // CHECK: Try '{{.*zomc}} compile --help' for more information.

--- a/products/zomlang/tests/language/expressions/template-literals.zom
+++ b/products/zomlang/tests/language/expressions/template-literals.zom
@@ -1,0 +1,96 @@
+// RUN: %zomc compile --dump-ast %s | %FileCheck %s
+
+let greeting = `hello`;
+let message = `hello ${name}, count ${count + 1}`;
+
+
+// CHECK: {
+// CHECK-NEXT:   "node": "SourceFile",
+// CHECK-NEXT:   "fileName": "{{.*template-literals.zom}}",
+// CHECK-NEXT:   "statements": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "greeting"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "TemplateLiteralExpression",
+// CHECK-NEXT:               "head": {
+// CHECK-NEXT:                 "node": "StringLiteral",
+// CHECK-NEXT:                 "value": "hello"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "spans": [
+// CHECK-NEXT: 
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "message"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": null,
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "TemplateLiteralExpression",
+// CHECK-NEXT:               "head": {
+// CHECK-NEXT:                 "node": "StringLiteral",
+// CHECK-NEXT:                 "value": "hello "
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "spans": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "node": "TemplateSpan",
+// CHECK-NEXT:                   "expression": {
+// CHECK-NEXT:                     "node": "Identifier",
+// CHECK-NEXT:                     "name": "name"
+// CHECK-NEXT:                   },
+// CHECK-NEXT:                   "literal": {
+// CHECK-NEXT:                     "node": "StringLiteral",
+// CHECK-NEXT:                     "value": ", count "
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "node": "TemplateSpan",
+// CHECK-NEXT:                   "expression": {
+// CHECK-NEXT:                     "node": "BinaryExpression",
+// CHECK-NEXT:                     "left": {
+// CHECK-NEXT:                       "node": "Identifier",
+// CHECK-NEXT:                       "name": "count"
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     "operator": {
+// CHECK-NEXT:                       "node": "TokenNode",
+// CHECK-NEXT:                       "symbol": "+"
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     "right": {
+// CHECK-NEXT:                       "node": "IntegerLiteral",
+// CHECK-NEXT:                       "value": "1"
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                   },
+// CHECK-NEXT:                   "literal": {
+// CHECK-NEXT:                     "node": "StringLiteral",
+// CHECK-NEXT:                     "value": ""
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }

--- a/products/zomlang/tests/language/interfaces/interface-declaration.zom
+++ b/products/zomlang/tests/language/interfaces/interface-declaration.zom
@@ -1,7 +1,7 @@
 // RUN: %zomc compile --dump-ast %s | %FileCheck %s
 
 interface Runnable {
-  fun run() -> void;
+  fun run() -> unit;
 }
 
 interface Comparable<T> {
@@ -40,8 +40,8 @@ interface Named {
 // CHECK-NEXT:           "returnType": {
 // CHECK-NEXT:             "node": "ReturnType",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:               "node": "TypeReferenceNode",
-// CHECK-NEXT:               "name": "void"
+// CHECK-NEXT:               "node": "UnitTypeNode",
+// CHECK-NEXT:               "name": "unit"
 // CHECK-NEXT:             }
 // CHECK-NEXT:           }
 // CHECK-NEXT:         }

--- a/products/zomlang/tests/language/statements/match.zom
+++ b/products/zomlang/tests/language/statements/match.zom
@@ -8,7 +8,7 @@ match (x) {
   when [a, b] => 2;
   when is i32 => 3;
   when x + 1 => 4;
-  // when Result.Ok(v: i32) => v;
+  when Result.Ok(v: i32) => v;
   default => return 0;
 }
 
@@ -27,11 +27,7 @@ match (x) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "node": "MatchClause",
 // CHECK-NEXT:           "pattern": {
-// CHECK-NEXT:             "node": "IdentifierPattern",
-// CHECK-NEXT:             "identifier": {
-// CHECK-NEXT:               "node": "Identifier",
-// CHECK-NEXT:               "name": "_"
-// CHECK-NEXT:             },
+// CHECK-NEXT:             "node": "WildcardPattern",
 // CHECK-NEXT:             "typeAnnotation": null
 // CHECK-NEXT:           },
 // CHECK-NEXT:           "guard": null,
@@ -51,7 +47,10 @@ match (x) {
 // CHECK-NEXT:               "node": "Identifier",
 // CHECK-NEXT:               "name": "v"
 // CHECK-NEXT:             },
-// CHECK-NEXT:             "typeAnnotation": null
+// CHECK-NEXT:             "typeAnnotation": {
+// CHECK-NEXT:               "node": "I32TypeNode",
+// CHECK-NEXT:               "name": "i32"
+// CHECK-NEXT:             }
 // CHECK-NEXT:           },
 // CHECK-NEXT:           "guard": null,
 // CHECK-NEXT:           "body": {
@@ -73,7 +72,10 @@ match (x) {
 // CHECK-NEXT:                   "node": "Identifier",
 // CHECK-NEXT:                   "name": "a"
 // CHECK-NEXT:                 },
-// CHECK-NEXT:                 "typeAnnotation": null
+// CHECK-NEXT:                 "typeAnnotation": {
+// CHECK-NEXT:                   "node": "I32TypeNode",
+// CHECK-NEXT:                   "name": "i32"
+// CHECK-NEXT:                 }
 // CHECK-NEXT:               },
 // CHECK-NEXT:               {
 // CHECK-NEXT:                 "node": "IdentifierPattern",
@@ -81,7 +83,10 @@ match (x) {
 // CHECK-NEXT:                   "node": "Identifier",
 // CHECK-NEXT:                   "name": "b"
 // CHECK-NEXT:                 },
-// CHECK-NEXT:                 "typeAnnotation": null
+// CHECK-NEXT:                 "typeAnnotation": {
+// CHECK-NEXT:                   "node": "StrTypeNode",
+// CHECK-NEXT:                   "name": "str"
+// CHECK-NEXT:                 }
 // CHECK-NEXT:               }
 // CHECK-NEXT:             ]
 // CHECK-NEXT:           },
@@ -193,6 +198,73 @@ match (x) {
 // CHECK-NEXT:             "expression": {
 // CHECK-NEXT:               "node": "IntegerLiteral",
 // CHECK-NEXT:               "value": "3"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         },
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "node": "MatchClause",
+// CHECK-NEXT:           "pattern": {
+// CHECK-NEXT:             "node": "ExpressionPattern",
+// CHECK-NEXT:             "expression": {
+// CHECK-NEXT:               "node": "BinaryExpression",
+// CHECK-NEXT:               "left": {
+// CHECK-NEXT:                 "node": "Identifier",
+// CHECK-NEXT:                 "name": "x"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "operator": {
+// CHECK-NEXT:                 "node": "TokenNode",
+// CHECK-NEXT:                 "symbol": "+"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "right": {
+// CHECK-NEXT:                 "node": "IntegerLiteral",
+// CHECK-NEXT:                 "value": "1"
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           },
+// CHECK-NEXT:           "guard": null,
+// CHECK-NEXT:           "body": {
+// CHECK-NEXT:             "node": "ExpressionStatement",
+// CHECK-NEXT:             "expression": {
+// CHECK-NEXT:               "node": "IntegerLiteral",
+// CHECK-NEXT:               "value": "4"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         },
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "node": "MatchClause",
+// CHECK-NEXT:           "pattern": {
+// CHECK-NEXT:             "node": "EnumPattern",
+// CHECK-NEXT:             "typeReference": {
+// CHECK-NEXT:               "node": "TypeReferenceNode",
+// CHECK-NEXT:               "name": "Result"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "propertyName": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "Ok"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "tuplePattern": {
+// CHECK-NEXT:               "node": "TuplePattern",
+// CHECK-NEXT:               "elements": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "node": "IdentifierPattern",
+// CHECK-NEXT:                   "identifier": {
+// CHECK-NEXT:                     "node": "Identifier",
+// CHECK-NEXT:                     "name": "v"
+// CHECK-NEXT:                   },
+// CHECK-NEXT:                   "typeAnnotation": {
+// CHECK-NEXT:                     "node": "I32TypeNode",
+// CHECK-NEXT:                     "name": "i32"
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           },
+// CHECK-NEXT:           "guard": null,
+// CHECK-NEXT:           "body": {
+// CHECK-NEXT:             "node": "ExpressionStatement",
+// CHECK-NEXT:             "expression": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "v"
 // CHECK-NEXT:             }
 // CHECK-NEXT:           }
 // CHECK-NEXT:         },

--- a/products/zomlang/tests/language/types/type-forms-error.zom
+++ b/products/zomlang/tests/language/types/type-forms-error.zom
@@ -1,6 +1,6 @@
 // RUN: ! %zomc compile --dump-ast %s 2>&1 | %FileCheck %s
 
-// Object type literals with string/numeric property names are not yet supported
+// Object type literals only allow identifier property names.
 let f: { x: i32, y?: str, "k": u8, 1: bool } = obj;
 
 

--- a/products/zomlang/tests/language/types/type-forms.zom
+++ b/products/zomlang/tests/language/types/type-forms.zom
@@ -1,6 +1,7 @@
 // RUN: %zomc compile --dump-ast %s 2>&1 | %FileCheck %s
 
 let a: i32[] = xs;
+let a16: i16 = small;
 let b: i32? = null;
 let c: (i32 | str)[] = xs;
 let d: A & B = x;
@@ -35,6 +36,29 @@ let i: typeof foo.bar = v;
 // CHECK-NEXT:             "initializer": {
 // CHECK-NEXT:               "node": "Identifier",
 // CHECK-NEXT:               "name": "xs"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "node": "VariableStatement",
+// CHECK-NEXT:       "declarations": {
+// CHECK-NEXT:         "node": "VariableDeclarationList",
+// CHECK-NEXT:         "bindings": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "node": "VariableDeclaration",
+// CHECK-NEXT:             "name": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "a16"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "type": {
+// CHECK-NEXT:               "node": "I16TypeNode",
+// CHECK-NEXT:               "name": "i16"
+// CHECK-NEXT:             },
+// CHECK-NEXT:             "initializer": {
+// CHECK-NEXT:               "node": "Identifier",
+// CHECK-NEXT:               "name": "small"
 // CHECK-NEXT:             }
 // CHECK-NEXT:           }
 // CHECK-NEXT:         ]

--- a/products/zomlang/tests/unittests/compiler/lexer/token-test.cc
+++ b/products/zomlang/tests/unittests/compiler/lexer/token-test.cc
@@ -269,6 +269,8 @@ ZC_TEST("TokenTest.OperatorStaticText") {
             "null"_zc);
 
   // Test types
+  ZC_EXPECT(ZC_ASSERT_NONNULL(Token::getStaticTextForTokenKind(ast::SyntaxKind::I16Keyword)) ==
+            "i16"_zc);
   ZC_EXPECT(ZC_ASSERT_NONNULL(Token::getStaticTextForTokenKind(ast::SyntaxKind::I32Keyword)) ==
             "i32"_zc);
   ZC_EXPECT(ZC_ASSERT_NONNULL(Token::getStaticTextForTokenKind(ast::SyntaxKind::F64Keyword)) ==

--- a/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
+++ b/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
@@ -878,7 +878,7 @@ ZC_TEST("ParserTest.ParseInterfaceDeclaration") {
   basic::StringPool stringPool;
 
   auto bufferId = sourceManager->addMemBufferCopy(
-      zc::str("interface Drawable { draw(): void; }").asBytes(), "test.zom");
+      zc::str("interface Drawable { draw(): unit; }").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
   auto result = parser.parse();
@@ -892,7 +892,7 @@ ZC_TEST("ParserTest.ParseInterfacePropertySignature") {
   basic::StringPool stringPool;
 
   auto bufferId = sourceManager->addMemBufferCopy(
-      zc::str("interface I { let x?: i32; const y: str; fun f<T>(a: i32) -> void; }").asBytes(),
+      zc::str("interface I { let x?: i32; const y: str; fun f<T>(a: i32) -> unit; }").asBytes(),
       "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
@@ -1067,7 +1067,7 @@ ZC_TEST("ParserTest.ParseTypeQueryInFunctionParameter") {
 
   // Test type query in function parameter type
   auto bufferId = sourceManager->addMemBufferCopy(
-      zc::str("fun test(param: typeof MyClass.method) -> void {}").asBytes(), "test.zom");
+      zc::str("fun test(param: typeof MyClass.method) -> unit {}").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
   auto result = parser.parse();
@@ -1385,8 +1385,8 @@ ZC_TEST("ParserTest.ParseUnaryOperators") {
   basic::LangOptions langOpts;
   basic::StringPool stringPool;
 
-  auto bufferId = sourceManager->addMemBufferCopy(
-      zc::str("void x; !true; ~x; +1; -1; -x ** 2;").asBytes(), "test.zom");
+  auto bufferId =
+      sourceManager->addMemBufferCopy(zc::str("!true; ~x; +1; -1; -x ** 2;").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
 
   auto result = parser.parse();
@@ -2920,6 +2920,20 @@ ZC_TEST("ParserTest.ParseTemplateLiteral") {
   ZC_EXPECT(result != zc::none);
 }
 
+ZC_TEST("ParserTest.ParseTemplateLiteralWithSubstitution") {
+  auto sourceManager = zc::heap<source::SourceManager>();
+  auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
+  basic::LangOptions langOpts;
+  basic::StringPool stringPool;
+
+  auto bufferId = sourceManager->addMemBufferCopy(
+      zc::str("let x = `hello ${name}, count ${count + 1}`;").asBytes(), "test.zom");
+  Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
+
+  auto result = parser.parse();
+  ZC_EXPECT(result != zc::none);
+}
+
 ZC_TEST("ParserTest.ParseStringLiteral") {
   auto sourceManager = zc::heap<source::SourceManager>();
   auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
@@ -3299,7 +3313,7 @@ ZC_TEST("ParserTest.ParseInterfaceWithModifiers") {
   ZC_EXPECT(result != zc::none);
 }
 
-/// Covers isStartOfStatement edge cases - do-while, switch
+/// Covers isStartOfStatement edge cases - do-while
 ZC_TEST("ParserTest.ParseDoWhileStatement") {
   auto sourceManager = zc::heap<source::SourceManager>();
   auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
@@ -3389,15 +3403,15 @@ ZC_TEST("ParserTest.ParseMatchWithArrayPattern") {
   ZC_EXPECT(result != zc::none);
 }
 
-/// Covers parsePropertyName - computed property names
-ZC_TEST("ParserTest.ParseComputedPropertyName") {
+/// Covers parsePropertyName - identifier property names
+ZC_TEST("ParserTest.ParseIdentifierPropertyName") {
   auto sourceManager = zc::heap<source::SourceManager>();
   auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
   basic::LangOptions langOpts;
   basic::StringPool stringPool;
 
-  auto bufferId = sourceManager->addMemBufferCopy(
-      zc::str("interface I { fun [key: str](); }").asBytes(), "test.zom");
+  auto bufferId =
+      sourceManager->addMemBufferCopy(zc::str("interface I { fun key(); }").asBytes(), "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
   auto result = parser.parse();
   ZC_EXPECT(result != zc::none);

--- a/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
+++ b/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
@@ -3425,13 +3425,14 @@ ZC_TEST("ParserTest.ParseMatchWithEnumPatternVariants") {
   basic::StringPool stringPool;
 
   auto bufferId = sourceManager->addMemBufferCopy(
-      zc::str("match result { Ok(value) => value, Result.Err => 0, _: i32 => 1, "
-              "value + 1 => 2 }")
+      zc::str("match (result) { when Ok(value) => value; when Result.Err => 0; "
+              "when _: i32 => 1; when value + 1 => 2; }")
           .asBytes(),
       "test.zom");
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
   auto result = parser.parse();
   ZC_EXPECT(result != zc::none);
+  ZC_EXPECT(!diagnosticEngine->hasErrors());
 }
 
 /// Covers parsePropertyName - identifier property names

--- a/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
+++ b/products/zomlang/tests/unittests/compiler/parser/parser-test.cc
@@ -2934,6 +2934,21 @@ ZC_TEST("ParserTest.ParseTemplateLiteralWithSubstitution") {
   ZC_EXPECT(result != zc::none);
 }
 
+ZC_TEST("ParserTest.ParseTemplateLiteralMissingCloseBrace") {
+  auto sourceManager = zc::heap<source::SourceManager>();
+  auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
+  basic::LangOptions langOpts;
+  basic::StringPool stringPool;
+
+  auto bufferId =
+      sourceManager->addMemBufferCopy(zc::str("let x = `hello ${name;").asBytes(), "test.zom");
+  Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
+
+  auto result = parser.parse();
+  ZC_EXPECT(result != zc::none);
+  ZC_EXPECT(diagnosticEngine->hasErrors());
+}
+
 ZC_TEST("ParserTest.ParseStringLiteral") {
   auto sourceManager = zc::heap<source::SourceManager>();
   auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
@@ -3403,6 +3418,22 @@ ZC_TEST("ParserTest.ParseMatchWithArrayPattern") {
   ZC_EXPECT(result != zc::none);
 }
 
+ZC_TEST("ParserTest.ParseMatchWithEnumPatternVariants") {
+  auto sourceManager = zc::heap<source::SourceManager>();
+  auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
+  basic::LangOptions langOpts;
+  basic::StringPool stringPool;
+
+  auto bufferId = sourceManager->addMemBufferCopy(
+      zc::str("match result { Ok(value) => value, Result.Err => 0, _: i32 => 1, "
+              "value + 1 => 2 }")
+          .asBytes(),
+      "test.zom");
+  Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
+  auto result = parser.parse();
+  ZC_EXPECT(result != zc::none);
+}
+
 /// Covers parsePropertyName - identifier property names
 ZC_TEST("ParserTest.ParseIdentifierPropertyName") {
   auto sourceManager = zc::heap<source::SourceManager>();
@@ -3415,6 +3446,20 @@ ZC_TEST("ParserTest.ParseIdentifierPropertyName") {
   Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
   auto result = parser.parse();
   ZC_EXPECT(result != zc::none);
+}
+
+ZC_TEST("ParserTest.ParseInvalidPropertyNames") {
+  auto sourceManager = zc::heap<source::SourceManager>();
+  auto diagnosticEngine = zc::heap<diagnostics::DiagnosticEngine>(*sourceManager);
+  basic::LangOptions langOpts;
+  basic::StringPool stringPool;
+
+  auto bufferId = sourceManager->addMemBufferCopy(
+      zc::str("interface I { [key]: i32; \"name\": str; 1: i32; }").asBytes(), "test.zom");
+  Parser parser(*sourceManager, *diagnosticEngine, langOpts, stringPool, bufferId);
+  auto result = parser.parse();
+  ZC_EXPECT(result != zc::none);
+  ZC_EXPECT(diagnosticEngine->hasErrors());
 }
 
 /// Covers parseBindingElement in destructuring


### PR DESCRIPTION
Summary:
- add template literal span parsing with lexer template rescanning
- preserve pattern type annotations and parse enum patterns
- treat i16 as a predefined type and update unit/fun-style docs

Validation:
- cmake --build --preset debug
- python3 scripts/check-format.py
- ctest --preset default -R 'parser-test|lexer-(basic|literal|operator)-test' --output-on-failure
- direct zomc + filecheck validation for updated lit snapshots